### PR TITLE
Fix authorization checker

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -245,12 +245,17 @@ func (api *API) tasksList(c *gin.Context) {
 	c.JSON(200, tasks)
 }
 
+func (api *API) ping(c *gin.Context){
+	c.JSON(200, "success")
+}
+
 func tokenMiddleware(c *gin.Context) {
 	token := c.Request.Header.Get("Authorization")
-	if len(token) != 42 {
+	//Token is 36 characters + 6 for Bearer prefix + 1 for space = 43
+	if len(token) != 43 {
 		c.AbortWithStatusJSON(401, gin.H{"detail": "incorrect auth token format"})
 	}
-	token = token[6:]
+	token = token[7:]
 	log.Println("Token: \"" + token + "\"")
 	db, dbCleanup := GetDBConnection()
 	defer dbCleanup()
@@ -272,6 +277,7 @@ func getRouter(api *API) *gin.Engine {
 	router.Use(tokenMiddleware)
 	// Authenticated endpoints
 	router.GET("/tasks/", api.tasksList)
+	router.GET("/ping/", api.ping)
 	return router
 }
 


### PR DESCRIPTION
As discussed on Slack, changed required length to 43 and added some tests. Wasn't sure the best way to test this without an endpoint because we need to simulate headers and seemed like bad practice to test another endpoint so I created a ping endpoint behind auth that always returns a `200` but open to changes here.

Also looks like 5e7ea71b7537c78b60d8ef211f35dc0d982fc382 broke tests so fixed those.