### PR TITLE
Increase instance size to t2 small and tag docker images with commit sha

### DIFF
--- a/backend/hooks/post_push
+++ b/backend/hooks/post_push
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+SHORTHASH="$(git rev-parse --short HEAD)"
+docker tag $IMAGE_NAME $DOCKER_REPO:$SHORTHASH
+docker push $DOCKER_REPO:$SHORTHASH

--- a/infrastructure/eks-cluster.tf
+++ b/infrastructure/eks-cluster.tf
@@ -15,7 +15,7 @@ module "eks" {
   worker_groups = [
     {
       name                          = "backend-servers"
-      instance_type                 = "t2.micro"
+      instance_type                 = "t2.small"
       asg_desired_capacity          = 2
       asg_min_size                  = 2
       asg_max_size                  = 4


### PR DESCRIPTION
turns out t2.micro can only handle 4 pods per instance, and our 2 pods + the 6 system pods maxed out the instances when we triggered a rolling deploy (increases the number of pods temporarily)