### PR TITLE
Shorten sender width in task header

### DIFF
--- a/frontend/mock-api.json
+++ b/frontend/mock-api.json
@@ -88,6 +88,23 @@
             "is_completable": false,
             "is_replyable": false
           }
+        },
+        {
+          "id": "5",
+          "id_external": "5",
+          "id_ordering": 5,
+          "datetime_end": null,
+          "datetime_start": null,
+          "deeplink": "https://gmail.com",
+          "sender": "Amazon.com Store Card Customer Service",
+          "title": "Your Amazon.com Store Card Statement from Synchrony Bank is Available Online Your Amazon.com Store Card Statement from Synchrony Bank is Available Online",
+          "body": "<div>hello world<br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/>sup<br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/>Goodbye world<div>",
+          "source": {
+            "name": "Gmail",
+            "logo": "/images/gmail.svg",
+            "is_completable": true,
+            "is_replyable": true
+          }
         }
       ]
     },
@@ -99,7 +116,7 @@
         {
           "id": "c72b41a6-c0d5-46bb-b868-f7021bdd8ae9",
           "id_external": "5pdjrip9j1pveo5ir1h5mbiaob",
-          "id_ordering": 5,
+          "id_ordering": 6,
           "datetime_start": "2021-03-11T12:00:00-07:00",
           "deeplink": "https://calendar.google.com",
           "sender": "",

--- a/frontend/src/components/task/TaskHeader.tsx
+++ b/frontend/src/components/task/TaskHeader.tsx
@@ -40,6 +40,8 @@ const Icon = styled.img`
 `
 const Source = styled.div`
   color: #cccccc;
+  max-width: 25%;
+  text-align: right;
 `
 const DoneButton = styled.button`
   background-color: white;


### PR DESCRIPTION
Shortened Sender field in task header to a max-width of 25%

Before:
![image](https://user-images.githubusercontent.com/42781446/121792780-eb284e00-cbad-11eb-82f3-2eb5d2706bc0.png)

After:
![image](https://user-images.githubusercontent.com/42781446/121792774-db106e80-cbad-11eb-94f7-fa32d5e0062a.png)

(Not seeing the email body not expanding bug though, maybe this is fixed?)