### PR TITLE
fixed moment warnings and added safari compat

### DIFF
--- a/backend/api/utils.go
+++ b/backend/api/utils.go
@@ -63,6 +63,7 @@ var ALLOWED_USERNAMES = map[string]struct{}{
 	"scottmai702@gmail.com":   {},
 	"sequoia@sequoiasnow.com": {},
 	"nolan1299@gmail.com":     {},
+	"jack_hamilton@me.com":    {},
 }
 
 func getTokenFromCookie(c *gin.Context) (*database.InternalAPIToken, error) {

--- a/frontend/src/components/task/TaskWrappers.tsx
+++ b/frontend/src/components/task/TaskWrappers.tsx
@@ -61,7 +61,7 @@ const ScheduledTask: React.FC<TaskGroupProps> = ({ taskGroup, index }: TaskGroup
   <>
     <TaskGroup>
       <TimeAnnotation>
-        <AlignRight>{moment(taskGroup.datetime_start).format('h:mm a')}</AlignRight>
+        <AlignRight>{momentFromDateTime(taskGroup.datetime_start).format('h:mm a')}</AlignRight>
       </TimeAnnotation>
       <Tasks>
         <Task
@@ -106,8 +106,8 @@ const UnscheduledTaskGroup: React.FC<TaskGroupProps> = ({ taskGroup, index }: Ta
 
 const TimeDuration: React.FC<TimeDurationProps> = ({ time_duration, datetime_start }: TimeDurationProps) => {
   const duration = moment.duration(time_duration * 1000)
-  const end = moment(datetime_start).add(duration)
-  const hasStarted = moment().isAfter(moment(datetime_start))
+  const end = momentFromDateTime(datetime_start).add(duration)
+  const hasStarted = moment().isAfter(momentFromDateTime(datetime_start))
 
   let initialTimeStr = ''
   if (hasStarted) {
@@ -162,6 +162,10 @@ const getTimeStr = (duration: moment.Duration): string => {
 
 const getLiveTimeStr = (end: Moment): string => {
   return getTimeStr(moment.duration(end.diff(moment())))
+}
+
+const momentFromDateTime = (date_time: string | null): Moment => {
+  return moment(date_time, 'YYYY-MM-DD HH:mm:ss ZZ')
 }
 
 export { ScheduledTask, UnscheduledTaskGroup }


### PR DESCRIPTION
Added functionality to properly parse datetime_start to avoid using deprecated functions. This fixes issues on safari where the start time of a task was not showing.