### PR TITLE
Asana: frontend should use "display_id" not "name"

### DIFF
--- a/frontend/src/components/settings/Account.tsx
+++ b/frontend/src/components/settings/Account.tsx
@@ -38,7 +38,7 @@ const Account: React.FC<Props> = ({ linkedAccount, removeLink }: Props) => (
   <AccountDiv>
     <AccountInfo>
       <AccountLogo src={linkedAccount.logo} alt={linkedAccount.name + ' logo'} />
-      <div>{linkedAccount.name}</div>
+      <div>{linkedAccount.display_id}</div>
     </AccountInfo>
     {linkedAccount.is_unlinkable && <RemoveLinkButton
       onClick={removeLink}


### PR DESCRIPTION
frontend should use "display_id" not "name" in linked accounts view

changed name to display_id in linked accounts:
![Screen Shot 2021-08-05 at 7 10 17 PM](https://user-images.githubusercontent.com/31417618/128445279-ba8aba6b-86a3-425e-b7ff-2140794b48c9.png)
