### PR TITLE
don't show time annotations on non-today tasks

### DIFF
--- a/frontend/src/components/task/TaskWrappers.tsx
+++ b/frontend/src/components/task/TaskWrappers.tsx
@@ -52,7 +52,7 @@ interface TaskGroupProps {
   showTimeAnnotations: boolean,
 }
 
-const ScheduledTask: React.FC<TaskGroupProps> = ({ taskGroup }: TaskGroupProps) => {
+const ScheduledTask: React.FC<TaskGroupProps> = ({ taskGroup, showTimeAnnotations }: TaskGroupProps) => {
   const time = useTimeDuration(taskGroup.time_duration, taskGroup.datetime_start)
   return <>
     <TaskGroup>
@@ -67,7 +67,7 @@ const ScheduledTask: React.FC<TaskGroupProps> = ({ taskGroup }: TaskGroupProps) 
         />
       </Tasks>
       <TimeAnnotation>
-        {time}
+        {showTimeAnnotations && time}
       </TimeAnnotation>
     </TaskGroup>
     <Divider />
@@ -75,7 +75,7 @@ const ScheduledTask: React.FC<TaskGroupProps> = ({ taskGroup }: TaskGroupProps) 
 }
 
 
-const UnscheduledTaskGroup: React.FC<TaskGroupProps> = ({ taskGroup }: TaskGroupProps) => {
+const UnscheduledTaskGroup: React.FC<TaskGroupProps> = ({ taskGroup, showTimeAnnotations }: TaskGroupProps) => {
   const time = useTimeDuration(taskGroup.time_duration, taskGroup.datetime_start)
   return <>
     <TaskGroup>
@@ -86,11 +86,13 @@ const UnscheduledTaskGroup: React.FC<TaskGroupProps> = ({ taskGroup }: TaskGroup
         ))}
       </Tasks>
       <TimeAnnotation>
-        <UnscheduledTimeAnnotationContainer>
-          <UnscheduledSpanbar />
-          <UnscheduledTimeSpacer />
-          {time}
-        </UnscheduledTimeAnnotationContainer>
+        {showTimeAnnotations &&
+          <UnscheduledTimeAnnotationContainer>
+            <UnscheduledSpanbar />
+            <UnscheduledTimeSpacer />
+            {time}
+          </UnscheduledTimeAnnotationContainer>
+        }
       </TimeAnnotation>
     </TaskGroup >
     <Divider />


### PR DESCRIPTION
removed time annotations on tasks that aren't in the today section by using the "showTimeAnnotations" tag
![Screen Shot 2021-08-05 at 7 53 14 PM](https://user-images.githubusercontent.com/31417618/128448909-4afb85bd-fe5c-4405-bac3-c11ac0e3c187.png)
