### PR TITLE
fixes truncation (forreal this time)

### DIFF
--- a/frontend/src/components/task/TaskHeader.tsx
+++ b/frontend/src/components/task/TaskHeader.tsx
@@ -23,10 +23,11 @@ const HeaderLeft = styled.div`
   align-items: center;
   flex-direction: row;
   min-width: 0;
+  flex-basis: auto;
 `
 const HeaderRight = styled.div`
-  flex: content;
   display: flex;
+  flex: content;
   align-items: center;
   flex-direction: row;
   justify-content: flex-end;


### PR DESCRIPTION
<img width="1052" alt="Screen Shot 2021-10-23 at 5 32 12 PM" src="https://user-images.githubusercontent.com/31417618/138574404-e7a1d902-7ffd-4dae-97c4-5f733fdb7183.png">
<img width="1056" alt="Screen Shot 2021-10-23 at 5 32 16 PM" src="https://user-images.githubusercontent.com/31417618/138574400-26e8057d-1fdf-4fee-8f90-7b4bbaa44409.png">


new behavior on chrome browser which fixes truncation to work like it does on safari