### PR TITLE
moved around returns and conditionals

### DIFF
--- a/frontend/mockAPI/mock-api.json
+++ b/frontend/mockAPI/mock-api.json
@@ -8,12 +8,12 @@
         {
           "type": "scheduled_task",
           "time_duration": 3600,
-          "datetime_start": "2021-10-24T18:05:00-08:00",
+          "datetime_start": "2021-10-25T07:39:00-07:00",
           "tasks": [
             {
               "id": "f2aba811-2bfd-4558-9ef0-96048a1e6b0b",
               "id_external": "5t1b86hbgvptrd1okidb3sd19m",
-              "datetime_start": "2021-10-24T18:05:00-08:00",
+              "datetime_start": "2021-10-25T07:39:00-07:00",
               "deeplink": "https://calendar.google.com",
               "sender": "",
               "link": "https://www.google.com/calendar/event?eid=NXQxYjg2aGJndnB0cmQxb2tpZGIzc2QxOW0gc2NvdHRtYWk3MDJAbQ",


### PR DESCRIPTION
Moved around code to isolate the hooks from conditional rendering, and instead handle most of the logic either: in the hook itself, or after the hook has been rendered.

Untested ATM, but this fixes the whitescreen/crash we were having when an event was starting or the tab was minimized for a while.  I will work on making sure this still fulfills all of our expected behaviors.