### PR TITLE
Fix task ordering bug

### DIFF
--- a/backend/api/task_list.go
+++ b/backend/api/task_list.go
@@ -256,7 +256,6 @@ func MergeTasks(
 		return []*TaskSection{}, err
 	}
 	newestEmailsFirst := *orderingSetting == settings.ChoiceKeyNewestFirst
-	log.Println("ordering setting:", *orderingSetting, settings.ChoiceKeyNewestFirst, "newest first:", newestEmailsFirst)
 
 	//first we sort the emails and tasks into a single array
 	sort.SliceStable(allUnscheduledTasks, func(i, j int) bool {
@@ -664,19 +663,14 @@ func compareEmails(e1 *database.Email, e2 *database.Email, newestEmailsFirst boo
 	e1Domain := utils.ExtractEmailDomain(e1.SourceAccountID)
 	e2Domain := utils.ExtractEmailDomain(e2.SourceAccountID)
 	if res := compareTaskBases(e1, e2); res != nil {
-		log.Println("compare1")
 		return *res
 	} else if e1.SenderDomain == e1Domain && e2.SenderDomain != e2Domain {
-		log.Println("compare2")
 		return true
 	} else if e1.SenderDomain != e1Domain && e2.SenderDomain == e2Domain {
-		log.Println("compare3")
 		return false
 	} else if newestEmailsFirst {
-		log.Println("compare4")
 		return e1.TimeSent > e2.TimeSent
 	} else {
-		log.Println("compare5")
 		return e1.TimeSent < e2.TimeSent
 	}
 }
@@ -725,13 +719,10 @@ func compareTaskBases(t1 interface{}, t2 interface{}) *bool {
 	tb2 := getTaskBase(t2)
 	var result bool
 	if tb1.HasBeenReordered && tb2.HasBeenReordered {
-		log.Println("compareBASE1")
 		result = tb1.IDOrdering < tb2.IDOrdering
 	} else if tb1.HasBeenReordered && !tb2.HasBeenReordered {
-		log.Println("compareBASE2")
 		result = true
 	} else if !tb1.HasBeenReordered && tb2.HasBeenReordered {
-		log.Println("compareBASE3")
 		result = false
 	} else {
 		return nil


### PR DESCRIPTION
We should only use id ordering as the primary ordering field if both tasks have been reordered.