### PR TITLE
Hide New button when tasks are loading

### DIFF
--- a/frontend/src/components/task/TasksPage.tsx
+++ b/frontend/src/components/task/TasksPage.tsx
@@ -72,10 +72,10 @@ export default function TasksPage(): JSX.Element {
 
 function CreateNewTaskButton(): JSX.Element {
     const { showButton } = useSelector((state: RootState) => ({
-        showButton: !(
-            state.tasks_page.task_sections.length === 0 &&
-            state.tasks_page.tasks_fetch_status.status === FetchStatusEnum.LOADING
-        ),
+        showButton:
+            state.tasks_page.task_sections.length !== 0 ||
+            state.tasks_page.tasks_fetch_status.status !== FetchStatusEnum.LOADING
+        ,
     }))
     return (
         <BtnContainer>


### PR DESCRIPTION
Previously, the "New" button would appear when the page first loaded: 
![image](https://user-images.githubusercontent.com/42781446/143145741-fb1b8814-715f-455f-9f3e-1904f71095be.png)

Now, it only shows when there are tasks present or tasks are not being loaded
![image](https://user-images.githubusercontent.com/42781446/143145830-ee455c19-c2c2-4a62-83d0-d85dee9eb802.png)
![image](https://user-images.githubusercontent.com/42781446/143145839-e5240a3d-5bbf-4f3a-9298-d30a3ff893e6.png)
