### PR TITLE
make email body height fit if message is short

### DIFF
--- a/frontend/src/components/task/TaskBody-style.tsx
+++ b/frontend/src/components/task/TaskBody-style.tsx
@@ -16,7 +16,8 @@ export const TaskBodyDiv = styled.div`
 export const EmailViewDiv = styled.div`
   width: auto;
   overflow: scroll;
-  height: 500px;
+  height: fit-content;
+  max-height: 500px;
   border-radius: 6px;
   padding: 10px;
   margin-top: 10px;


### PR DESCRIPTION
set max height to 500px
<img width="1080" alt="Screen Shot 2021-12-16 at 5 18 58 PM" src="https://user-images.githubusercontent.com/9156543/146472937-3bf035b0-252e-4432-8284-d4c5a9b0d0d2.png">
<img width="1086" alt="Screen Shot 2021-12-16 at 5 19 25 PM" src="https://user-images.githubusercontent.com/9156543/146472945-b9b0b9df-7994-44b1-b571-66ddc23ac06f.png">
