### PR TITLE
Fix task not expanding on click bug

### DIFF
--- a/frontend/src/components/task/TaskHeader.tsx
+++ b/frontend/src/components/task/TaskHeader.tsx
@@ -89,13 +89,13 @@ const TaskHeader = React.forwardRef<HTMLDivElement, TaskHeaderProps>((props: Tas
         }
         {
           props.task.source.is_completable &&
-          <DoneButton src={DONE_BUTTON} onClick={(e) =>{
+          <DoneButton src={DONE_BUTTON} onClick={(e) => {
             e.stopPropagation()
             onDoneButtonClick()
-          }}/>
+          }} />
         }
         <Icon src={props.task.source.logo} alt="icon"></Icon>
-        <Title isExpanded={props.isExpanded} onClick={(e) => e.stopPropagation()}>{props.task.title} </Title>
+        <Title isExpanded={props.isExpanded}>{props.task.title} </Title>
       </HeaderLeft>
       <HeaderRight>
         {hoverEffectEnabled &&


### PR DESCRIPTION
Maybe this was on purpose, but currently tasks don't expand/collapse if you click on the text of the title. I thought this was a bug when i tried out the app - lmk if this is intended