### PR TITLE
Fixes drag/drop

### DIFF
--- a/frontend/src/helpers/utils.ts
+++ b/frontend/src/helpers/utils.ts
@@ -111,7 +111,7 @@ export function emptyFunction(): void { }
 export const updateOrderingIds = (task_sections: TTaskSection[]): TTaskSection[] => {
     return task_sections.map((section) => {
         let idOrdering = 1
-        section.tasks.forEach((task) => (task.id_ordering = idOrdering++))
+        section.tasks?.forEach((task) => (task.id_ordering = idOrdering++))
         return section
     })
 }


### PR DESCRIPTION
Dragging from an otherwise empty blocked to an empty backlog would error out.

No longer.

This change is 1 character