### PR TITLE
Fix: Warning from keyboard shortcut logic

### DIFF
--- a/frontend/src/components/task/TaskCreate.tsx
+++ b/frontend/src/components/task/TaskCreate.tsx
@@ -1,7 +1,7 @@
 import * as styles from './TaskCreate-style'
 
 import { GT_TASK_SOURCE_ID, TASKS_CREATE_URL } from '../../constants'
-import React, { useRef, useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { logEvent, makeAuthorizedRequest } from '../../helpers/utils'
 import { useAppDispatch, useAppSelector } from '../../redux/hooks'
 
@@ -24,10 +24,13 @@ export default function TaskCreate(): JSX.Element {
 
     const titleRef = useRef<HTMLInputElement>(null)
 
-    if (focusCreateTaskForm) {
-        titleRef.current?.focus()
-        dispatch(setFocusCreateTaskForm(false))
-    }
+    useEffect(() => {
+        if (focusCreateTaskForm) {
+            titleRef.current?.focus()
+            dispatch(setFocusCreateTaskForm(false))
+        }
+    }, [focusCreateTaskForm])
+
 
     return <>
         <styles.OuterContainer>


### PR DESCRIPTION
added useffect to prevent parent from changing child state while child is rendering
More info about this error here: https://github.com/facebook/react/issues/18178
<img width="2047" alt="Screen Shot 2022-02-02 at 9 42 43 AM" src="https://user-images.githubusercontent.com/9156543/152209239-178dc1cf-6959-40bb-a0f8-cb1952976ac0.png">
