### PR TITLE
Refactored task actions to use component format

### DIFF
--- a/frontend/src/components/task/header/Actions.tsx
+++ b/frontend/src/components/task/header/Actions.tsx
@@ -36,11 +36,11 @@ interface ExpandActionProps {
     isExpanded: boolean,
     taskId: string,
 }
-const ExpandAction = (props: ExpandActionProps): JSX.Element => {
+const ExpandAction = ({ isExpanded, taskId }: ExpandActionProps): JSX.Element => {
     const dispatch = useAppDispatch()
     const onClick = (e: React.MouseEvent) => {
         e.stopPropagation()
-        dispatch(props.isExpanded ? collapseBody() : expandBody(props.taskId))
+        dispatch(isExpanded ? collapseBody() : expandBody(taskId))
     }
     return (
         <Tooltip text={'Expand/Collapse'}>


### PR DESCRIPTION
While adding keyboard shortcuts I ran into this section

I think we should avoid creating components through function call format and instead use JSX format

i.e. `<TasksPage />` instead of `const tasksPage = TasksPage()` 