### PR TITLE
this is a fix for the chrome drag preview error

### DIFF
--- a/frontend/src/components/task/Task-style.tsx
+++ b/frontend/src/components/task/Task-style.tsx
@@ -6,6 +6,7 @@ export const DraggableContainer = styled.div`
     min-width: 500px;
     margin: 5px 0;
     position: relative;
+    transform: translate3d(0, 0, 0);
 `
 
 export const TaskContainer = styled.div<{


### PR DESCRIPTION
In the future we probably want to use a draglayer to replace the preview

on chrome: 
<img width="1133" alt="Screen Shot 2022-02-07 at 2 01 31 PM" src="https://user-images.githubusercontent.com/9156543/152879530-8b3fb057-37b9-47f9-91ce-743ed949fe57.png">
