### PR TITLE
Adds outside click handler

### DIFF
--- a/frontend/src/components/messages/Message.tsx
+++ b/frontend/src/components/messages/Message.tsx
@@ -4,7 +4,7 @@ import { TMessage } from '../../helpers/types'
 import { useAppDispatch, useAppSelector } from '../../redux/hooks'
 import { useFetchMessages } from './MessagesPage'
 import { collapseBody, expandBody } from '../../redux/messagesPageSlice'
-import { logEvent, makeAuthorizedRequest } from '../../helpers/utils'
+import { logEvent, makeAuthorizedRequest, useClickOutside } from '../../helpers/utils'
 import { LogEvents } from '../../helpers/enums'
 import { ButtonIcon, ButtonRight, ButtonRightContainer, HeaderLeft, HeaderRight, TaskHeaderContainer } from '../task/header/Header-style'
 import { EXPAND_ICON, MESSAGES_MODIFY_URL } from '../../constants'
@@ -89,13 +89,19 @@ interface MessageProps {
     message: TMessage
 }
 export default function Message(props: MessageProps): JSX.Element {
+    const dispatch = useAppDispatch()
     const { message } = props
     const { isBodyExpanded } = useAppSelector((state) => ({
         isBodyExpanded: state.messages_page.messages.expanded_body === message.id,
     }))
 
+    const containerRef = React.useRef<HTMLDivElement>(null)
+    useClickOutside(containerRef, () => {
+        isBodyExpanded && dispatch(collapseBody())
+    })
+
     return (
-        <MessageContainer isExpanded={isBodyExpanded}>
+        <MessageContainer isExpanded={isBodyExpanded} ref={containerRef}>
             <MessageHeader message={message} isExpanded={isBodyExpanded} />
             <MessageBody message={message} isExpanded={isBodyExpanded} />
         </MessageContainer>

--- a/frontend/src/components/task/Task.tsx
+++ b/frontend/src/components/task/Task.tsx
@@ -6,9 +6,11 @@ import { Indices, ItemTypes } from '../../helpers/types'
 import React from 'react'
 import { TTask } from '../../helpers/types'
 import TaskBody from './TaskBody'
-import { useAppSelector } from '../../redux/hooks'
+import { useAppDispatch, useAppSelector } from '../../redux/hooks'
 import { useDrag } from 'react-dnd'
 import TaskHeader from './header/Header'
+import { useClickOutside } from '../../helpers/utils'
+import { collapseBody } from '../../redux/tasksPageSlice'
 
 interface Props {
     task: TTask
@@ -19,6 +21,7 @@ interface Props {
 }
 
 export default function Task(props: Props): JSX.Element {
+    const dispatch = useAppDispatch()
     const { task, dragDisabled, isOver, dropDirection } = props
     const { isBodyExpanded } = useAppSelector((state) => ({
         isBodyExpanded: state.tasks_page.tasks.expanded_body === task.id,
@@ -35,10 +38,15 @@ export default function Task(props: Props): JSX.Element {
         },
     }))
 
+    const containerRef = React.useRef<HTMLDivElement>(null)
+    useClickOutside(containerRef, () => {
+        isBodyExpanded && dispatch(collapseBody())
+    })
+
     return (
         <DraggableContainer ref={dragPreview}>
             <DropIndicatorAbove isVisible={isOver && dropDirection} />
-            <TaskContainer opacity={opacity} isExpanded={isBodyExpanded}>
+            <TaskContainer opacity={opacity} isExpanded={isBodyExpanded} ref={containerRef}>
                 <TaskHeader task={task} dragDisabled={dragDisabled} isExpanded={isBodyExpanded} ref={drag} />
                 <TaskBody task={task} isExpanded={isBodyExpanded} />
             </TaskContainer>

--- a/frontend/src/helpers/utils.ts
+++ b/frontend/src/helpers/utils.ts
@@ -199,3 +199,18 @@ export function stopKeyboardPropogation(e: React.KeyboardEvent) {
         e.stopPropagation()
     }
 }
+
+export function useClickOutside(ref: React.RefObject<HTMLElement>, handler: () => void): void {
+    useEffect(() => {
+        const listener = (event: MouseEvent) => {
+            if (!ref.current || ref.current.contains(event.target as Node)) {
+                return
+            }
+            handler()
+        }
+        document.addEventListener('click', listener, true)
+        return () => {
+            document.removeEventListener('click', listener, true)
+        }
+    }, [ref, handler])
+}


### PR DESCRIPTION
Allows clicks outside of tasks to collapse them.

Adds a utility method for detecting clicks outside of the element and its children.

Let me know if this is not convention or if there's a better way to do this.  Right now, I believe it serves the functionality we want, but using eventlisteners like this makes me feel dirty.