### PR TITLE
Some Keyboard Shortcuts for Tasks

### DIFF
--- a/frontend/src/components/common/ExpandCollapse.tsx
+++ b/frontend/src/components/common/ExpandCollapse.tsx
@@ -1,6 +1,7 @@
-import styled from 'styled-components'
 import { ICON_HOVER } from '../../helpers/styles'
 import React from 'react'
+import styled from 'styled-components'
+import { useKeyboardShortcut } from './KeyboardShortcut'
 
 export const HoverButton = styled.button`
     background-color: transparent;
@@ -27,6 +28,7 @@ interface Props {
     onClick: () => void
 }
 export default function ExpandCollapse({ direction, onClick }: Props): JSX.Element {
+    useKeyboardShortcut('c', onClick)
     return (
         <HoverButton onClick={onClick}>
             <Icon

--- a/frontend/src/components/common/Tooltip.tsx
+++ b/frontend/src/components/common/Tooltip.tsx
@@ -1,7 +1,8 @@
 import React, { useRef } from 'react'
-import styled from 'styled-components'
+import { SHADOW_MISC_1, TOOLTIPS_BACKGROUND, TOOLTIPS_HEIGHT, TOOLTIPS_OPACITY } from '../../helpers/styles'
+
 import { TOOLTIP_DELAY } from '../../constants'
-import { TOOLTIPS_BACKGROUND, TOOLTIPS_OPACITY, TOOLTIPS_HEIGHT, SHADOW_MISC_1 } from '../../helpers/styles'
+import styled from 'styled-components'
 
 const RelativeDiv = styled.div`
     position: relative;
@@ -43,8 +44,11 @@ const TooltipContainer = styled.div<{ show: boolean, direction: string }>`
         'top: calc(100% + var(--tooltip-spacing))'
     };
 `
+
+type Children = JSX.Element | JSX.Element[] | boolean | null | undefined | Element | Element[] | string | number
+
 interface TooltipProps {
-    children: JSX.Element | JSX.Element[],
+    children: Children | Children[],
     text: string,
     placement?: 'above' | 'below',
 }

--- a/frontend/src/components/task/Task.tsx
+++ b/frontend/src/components/task/Task.tsx
@@ -1,16 +1,16 @@
 import './Task.css'
 
-import { TaskContainer, DraggableContainer, DropIndicatorAbove, DropIndicatorBelow } from './Task-style'
+import { DraggableContainer, DropIndicatorAbove, DropIndicatorBelow, TaskContainer } from './Task-style'
 import { Indices, ItemTypes } from '../../helpers/types'
+import { useAppDispatch, useAppSelector } from '../../redux/hooks'
 
 import React from 'react'
 import { TTask } from '../../helpers/types'
 import TaskBody from './TaskBody'
-import { useAppDispatch, useAppSelector } from '../../redux/hooks'
-import { useDrag } from 'react-dnd'
 import TaskHeader from './header/Header'
-import { useClickOutside } from '../../helpers/utils'
 import { collapseBody } from '../../redux/tasksPageSlice'
+import { useClickOutside } from '../../helpers/utils'
+import { useDrag } from 'react-dnd'
 
 interface Props {
     task: TTask

--- a/frontend/src/components/task/header/Header.tsx
+++ b/frontend/src/components/task/header/Header.tsx
@@ -1,4 +1,5 @@
 import { Action, Dispatch } from '@reduxjs/toolkit'
+import { DONE_BUTTON, TASKS_MODIFY_URL, UNDONE_BUTTON } from '../../../constants'
 import {
     DoneButton,
     DoneButtonContainer,
@@ -8,17 +9,18 @@ import {
     TaskHeaderContainer,
 } from './Header-style'
 import React, { useCallback } from 'react'
-import { DONE_BUTTON, TASKS_MODIFY_URL, UNDONE_BUTTON } from '../../../constants'
-import { LogEvents } from '../../../helpers/enums'
-import { TTask } from '../../../helpers/types'
-import { logEvent, makeAuthorizedRequest } from '../../../helpers/utils'
-import { useAppDispatch } from '../../../redux/hooks'
 import { collapseBody, expandBody, hideDatePicker, hideLabelSelector, hideTimeEstimate, removeTaskByID } from '../../../redux/tasksPageSlice'
+import { logEvent, makeAuthorizedRequest } from '../../../helpers/utils'
+
 import Domino from '../../common/Domino'
 import { EditableTaskTitle } from '../../common/Title'
-import Tooltip from '../../common/Tooltip'
-import { useFetchTasks } from '../TasksPage'
 import HeaderActions from './Actions'
+import { InvisibleKeyboardShortcut } from '../../common/KeyboardShortcut'
+import { LogEvents } from '../../../helpers/enums'
+import { TTask } from '../../../helpers/types'
+import Tooltip from '../../common/Tooltip'
+import { useAppDispatch } from '../../../redux/hooks'
+import { useFetchTasks } from '../TasksPage'
 
 const done = async (task_id: string, new_state: boolean, dispatch: Dispatch<Action<string>>, fetchTasks: () => void) => {
     try {
@@ -63,8 +65,11 @@ const TaskHeader = React.forwardRef<HTMLDivElement, TaskHeaderProps>((props: Tas
         dispatch(props.isExpanded ? collapseBody() : expandBody(props.task.id))
     }
 
+    const isSelected = props.isExpanded // || isSelectedThroughKeyboardShortcut (coming soon)
+
     return (
         <TaskHeaderContainer showButtons={props.isExpanded} onMouseOver={() => { setIsOver(true) }} onMouseLeave={onMouseLeave} onClick={onClick} >
+            {props.isExpanded && <InvisibleKeyboardShortcut shortcut="d" onKeyPress={onDoneButtonClick} />}
             <HeaderLeft>
                 {
                     !props.dragDisabled &&
@@ -86,7 +91,7 @@ const TaskHeader = React.forwardRef<HTMLDivElement, TaskHeaderProps>((props: Tas
                 <Icon src={props.task.source.logo} alt='icon'></Icon>
                 <EditableTaskTitle task={props.task} isExpanded={props.isExpanded} />
             </HeaderLeft >
-            <HeaderActions isOver={isOver} task={props.task} isExpanded={props.isExpanded} />
+            <HeaderActions isOver={isOver} task={props.task} isExpanded={props.isExpanded} isSelected={isSelected} />
         </TaskHeaderContainer >
     )
 })

--- a/frontend/src/redux/tasksPageSlice.ts
+++ b/frontend/src/redux/tasksPageSlice.ts
@@ -12,6 +12,7 @@ export interface TasksPageState {
         time_estimate: string | null,
         label_selector: string | null,
         focus_create_task_form: boolean,
+        selected_task_id: string | null,
     },
     events: {
         event_list: TEvent[]
@@ -30,6 +31,7 @@ const initialState: TasksPageState = {
         time_estimate: null,
         label_selector: null,
         focus_create_task_form: false,
+        selected_task_id: '61fd8798e1bdcee3b675a2da',
     },
     events: {
         event_list: [],
@@ -105,6 +107,9 @@ export const tasksPageSlice = createSlice({
         setShowModal(state, action: PayloadAction<boolean>) {
             state.events.show_modal = action.payload
         },
+        setSelectedTask(state, action: PayloadAction<string | null>) {
+            state.tasks.selected_task_id = action.payload
+        },
     },
 })
 
@@ -124,7 +129,8 @@ export const {
     setEvents,
     setEventsFetchStatus,
     setShowCalendarSidebar,
-    setShowModal
+    setShowModal,
+    setSelectedTask,
 } = tasksPageSlice.actions
 
 export default tasksPageSlice.reducer


### PR DESCRIPTION
- Added <InvisibleKeyboardShortcut /> component so that kb shortcut state is self contained without displaying a button indicator
Added some keyboard shortcuts based on the figma legend
- Added "C" shortcut to open/close calendar
When a task is "selected" (for now just means expanded)
- "F" opens the time estimate
- "S" opens the Due date
- "L" opens the Label
- "Enter" collapses the task (will also expand once kb selection is added)

- One bug is that if the user holds down a key (i.e. "C") the keyboard shortcut will be rapidly triggered - will address in a future PR