### PR TITLE
Allow labelling done tasks

### DIFF
--- a/frontend/src/components/task/header/Actions.tsx
+++ b/frontend/src/components/task/header/Actions.tsx
@@ -157,18 +157,12 @@ const HeaderActions = (props: HeaderActionsProps) => {
 
     if (props.isOver || props.isExpanded) {
         actions = [
+            { key: 'S', component: <DueDateAction taskId={props.task.id} dueDate={props.task.due_date} /> },
+            { key: 'F', component: <TimeEstimateAction sourceName="General Task" taskId={props.task.id} timeAllocated={props.task.time_allocated} /> },
+            { key: 'L', component: <LabelAction task={props.task} /> },
             { key: 'Enter', component: <ExpandAction isExpanded={props.isExpanded} taskId={props.task.id} /> },
             ...actions
         ]
-        if (!props.task.is_done) {
-            actions = [
-                { key: 'L', component: <LabelAction task={props.task} /> },
-                ...actions]
-        }
-        actions = [
-            { key: 'F', component: <TimeEstimateAction sourceName="General Task" taskId={props.task.id} timeAllocated={props.task.time_allocated} /> },
-            { key: 'S', component: <DueDateAction taskId={props.task.id} dueDate={props.task.due_date} /> },
-            ...actions]
 
     }
     else {

--- a/frontend/src/components/task/header/options/Label.tsx
+++ b/frontend/src/components/task/header/options/Label.tsx
@@ -43,6 +43,7 @@ export default function Label({ task }: LabelProps): JSX.Element {
                                 const patchBody = JSON.stringify({
                                     id_task_section: newSection.id,
                                     id_ordering: newTaskSections[newSectionIndex].tasks[0].id_ordering,
+                                    is_completed: false,
                                 })
 
                                 makeAuthorizedRequest({


### PR DESCRIPTION
This PR adds back the label button for tasks in the 'done' section and marks them as incomplete when moved back into a standard task section
<img width="599" alt="Screen Shot 2022-02-09 at 10 24 28 AM" src="https://user-images.githubusercontent.com/31417618/153265495-dfcb5761-d30c-404e-8b39-7a1bcd30d4cd.png">

