### PR TITLE
Change messages endpoints to filter only unread messages

### DIFF
--- a/backend/api/messages_fetch.go
+++ b/backend/api/messages_fetch.go
@@ -38,7 +38,7 @@ func (api *API) MessagesFetch(c *gin.Context) {
 		return
 	}
 
-	currentEmails, err := database.GetActiveEmails(db, userID.(primitive.ObjectID))
+	currentEmails, err := database.GetUnreadEmails(db, userID.(primitive.ObjectID))
 	if err != nil {
 		Handle500(c)
 		return

--- a/backend/api/messages_list.go
+++ b/backend/api/messages_list.go
@@ -60,7 +60,7 @@ func (api *API) MessagesList(c *gin.Context) {
 		return
 	}
 
-	currentEmails, err := database.GetActiveEmails(db, userID.(primitive.ObjectID))
+	currentEmails, err := database.GetUnreadEmails(db, userID.(primitive.ObjectID))
 	if err != nil {
 		Handle500(c)
 		return
@@ -244,7 +244,7 @@ func (api *API) emailToMessage(e *database.Item) *message {
 		Body:     e.Body,
 		Sender:   e.Sender,
 		SentAt:   e.CreatedAtExternal.Time().Format(time.RFC3339),
-		IsUnread: true,
+		IsUnread: e.Email.IsUnread,
 		Source: messageSource{
 			AccountId:     e.SourceAccountID,
 			Name:          messageSourceResult.Details.Name,

--- a/backend/api/messages_list_v2.go
+++ b/backend/api/messages_list_v2.go
@@ -36,7 +36,7 @@ func (api *API) MessagesListV2(c *gin.Context) {
 		return
 	}
 
-	emails, err := database.GetActiveEmails(db, userID.(primitive.ObjectID))
+	emails, err := database.GetUnreadEmails(db, userID.(primitive.ObjectID))
 	if err != nil {
 		Handle500(c)
 		return

--- a/backend/database/helpers.go
+++ b/backend/database/helpers.go
@@ -190,7 +190,7 @@ func GetActiveTasks(db *mongo.Database, userID primitive.ObjectID) (*[]Item, err
 	return &tasks, nil
 }
 
-func GetActiveEmails(db *mongo.Database, userID primitive.ObjectID) (*[]Item, error) {
+func GetUnreadEmails(db *mongo.Database, userID primitive.ObjectID) (*[]Item, error) {
 	parentCtx := context.Background()
 	dbCtx, cancel := context.WithTimeout(parentCtx, constants.DatabaseTimeout)
 	defer cancel()
@@ -199,8 +199,8 @@ func GetActiveEmails(db *mongo.Database, userID primitive.ObjectID) (*[]Item, er
 		bson.M{
 			"$and": []bson.M{
 				{"user_id": userID},
-				{"is_completed": false},
 				{"task_type.is_message": true},
+				{"email.is_unread": true},
 			},
 		},
 	)

--- a/backend/database/helpers_test.go
+++ b/backend/database/helpers_test.go
@@ -169,7 +169,7 @@ func TestMarkItemComplete(t *testing.T) {
 	})
 }
 
-func TestGetActiveEmails(t *testing.T) {
+func TestGetUnreadEmails(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		db, dbCleanup, err := GetDBConnection()
 		assert.NoError(t, err)
@@ -184,9 +184,31 @@ func TestGetActiveEmails(t *testing.T) {
 			&Item{
 				Email: Email{
 					SenderDomain: "gmail",
+					IsUnread: true,
 				},
 				TaskBase: TaskBase{
 					IDExternal: "123abc",
+					SourceID:   "gmail",
+					UserID:     userID,
+				},
+				TaskType: TaskType{
+					IsMessage: true,
+				},
+			},
+		)
+		assert.NoError(t, err)
+		_, err = GetOrCreateTask(
+			db,
+			userID,
+			"123abcdef",
+			"gmail",
+			&Item{
+				Email: Email{
+					SenderDomain: "gmail",
+					IsUnread: false,
+				},
+				TaskBase: TaskBase{
+					IDExternal: "123abcdef",
 					SourceID:   "gmail",
 					UserID:     userID,
 				},
@@ -229,7 +251,7 @@ func TestGetActiveEmails(t *testing.T) {
 		)
 		assert.NoError(t, err)
 
-		emails, err := GetActiveEmails(db, userID)
+		emails, err := GetUnreadEmails(db, userID)
 		assert.NoError(t, err)
 		assert.Equal(t, 1, len(*emails))
 		assert.Equal(t, task1.ID, (*emails)[0].ID)


### PR DESCRIPTION
We were still filtering emails by `is_completed`, and once frontend cut over to fetch/retrieve messages endpoints, they this field wasn't getting updated in the fetch (as expected)