### PR TITLE
Stop asana task modification from setting due date to 0

### DIFF
--- a/backend/constants/time.go
+++ b/backend/constants/time.go
@@ -9,3 +9,4 @@ const MONTH int = 30 * DAY
 const YEAR int = 365 * DAY
 
 const NANOSECONDS_IN_SECOND int64 = 1000 * 1000
+const YEAR_MONTH_DAY_FORMAT string = "2006-01-02"

--- a/backend/external/asana_task.go
+++ b/backend/external/asana_task.go
@@ -193,7 +193,7 @@ func (asanaTask AsanaTaskSource) ModifyTask(userID primitive.ObjectID, accountID
 func (asanaTask AsanaTaskSource) GetTaskUpdateBody(updateFields *database.TaskChangeableFields) *AsanaTasksUpdateBody {
 	var dueDate *string
 	if updateFields.DueDate.Time() != time.Unix(0, 0) {
-		dueDateString := updateFields.DueDate.Time().Format("2006-01-02T15:04:05Z07:00")
+		dueDateString := updateFields.DueDate.Time().Format(constants.YEAR_MONTH_DAY_FORMAT)
 		dueDate = &dueDateString
 	}
 	body := AsanaTasksUpdateBody{

--- a/backend/external/asana_task_test.go
+++ b/backend/external/asana_task_test.go
@@ -376,7 +376,8 @@ func TestModifyAsanaTask(t *testing.T) {
 	t.Run("GetTaskUpdateBodyWithDueDate", func(t *testing.T) {
 		title := "Title"
 		description := "Body"
-		date := "2022-02-27T00:00:00-08:00"
+		date := "2022-02-27T08:00:00Z"
+		shortenedDate := "2022-02-27"
 		dueDate, _ := time.Parse(time.RFC3339, date)
 		timeAllocation := int64(1000)
 		isCompleted := true
@@ -392,7 +393,7 @@ func TestModifyAsanaTask(t *testing.T) {
 			Data: AsanaTasksUpdateFields{
 				Name:      &title,
 				Notes:     &description,
-				DueOn:     &date,
+				DueOn:     &shortenedDate,
 				Completed: &isCompleted,
 			},
 		}


### PR DESCRIPTION
There is still a bug where asana tasks appear as being due a day earlier than it is on Asana, its related to time zones and how due dates are being stored on our end. 