### PR TITLE
Add date and time picker components

### DIFF
--- a/frontend-new/package.json
+++ b/frontend-new/package.json
@@ -10,6 +10,7 @@
     "eject": "expo eject"
   },
   "dependencies": {
+    "@react-native-community/datetimepicker": "4.0.0",
     "@react-native-community/masked-view": "^0.1.11",
     "@react-navigation/drawer": "^6.3.1",
     "@react-navigation/native": "^6.0.8",

--- a/frontend-new/src/components/atoms/GTDateTimePicker.tsx
+++ b/frontend-new/src/components/atoms/GTDateTimePicker.tsx
@@ -1,0 +1,53 @@
+import React, { useState } from 'react'
+import { View, Text } from 'react-native'
+import DateTimePicker, { IOSNativeProps } from '@react-native-community/datetimepicker'
+
+interface TimePickerProps {
+    initialValue?: Date
+    onChange: (date: Date) => void
+}
+export const TimePicker = ({ initialValue, onChange }: TimePickerProps) => {
+    const [val, setVal] = useState(initialValue || new Date(0))
+
+    const props: IOSNativeProps = {
+        value: val,
+        mode: 'countdown',
+        onChange: (_, date?: Date | undefined) => {
+            const currentDate = date || val
+            setVal(currentDate)
+            onChange(currentDate)
+        },
+    }
+
+    return (
+        <View>
+            <DateTimePicker {...props} />
+            <Text>{`${val.getHours()}H${val.getMinutes()}M`}</Text>
+        </View>
+    )
+}
+
+interface DatePickerProps {
+    initialValue?: Date
+    onChange: (date: Date) => void
+}
+export const DatePicker = ({ initialValue, onChange }: DatePickerProps) => {
+    const [val, setVal] = useState(initialValue || new Date())
+
+    const props: IOSNativeProps = {
+        value: val,
+        mode: 'date',
+        onChange: (_, date?: Date | undefined) => {
+            const currentDate = date || val
+            setVal(currentDate)
+            onChange(currentDate)
+        },
+    }
+
+    return (
+        <View>
+            <DateTimePicker {...props} />
+            <Text>{`${val.toISOString()}`}</Text>
+        </View>
+    )
+}

--- a/frontend-new/yarn.lock
+++ b/frontend-new/yarn.lock
@@ -1499,6 +1499,13 @@
     sudo-prompt "^9.0.0"
     wcwidth "^1.0.1"
 
+"@react-native-community/datetimepicker@4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@react-native-community/datetimepicker/-/datetimepicker-4.0.0.tgz#4629ac3d8d54b4024385f2b2a30bbe13640c6ed3"
+  integrity sha512-q3JfDHX5PI0AxFeMsB6jcHSXODloXAqBVsOfkIvm+YbAe1TUs/xZ3qGazsKVBk9EdFyHO4k+S1Q8tQkEnk2YrQ==
+  dependencies:
+    invariant "^2.2.4"
+
 "@react-native-community/masked-view@^0.1.11":
   version "0.1.11"
   resolved "https://registry.yarnpkg.com/@react-native-community/masked-view/-/masked-view-0.1.11.tgz#2f4c6e10bee0786abff4604e39a37ded6f3980ce"


### PR DESCRIPTION
This just adds the components, nothing displayed is different and no functionality is changing.  This PR's purpose is to save the existing state of the components I worked on for the future when we implement date/time picking for mobile.