### PR TITLE
Added new logo field to task source

### DIFF
--- a/backend/api/task_list.go
+++ b/backend/api/task_list.go
@@ -19,6 +19,7 @@ import (
 type TaskSource struct {
 	Name          string `json:"name"`
 	Logo          string `json:"logo"`
+	LogoV2        string `json:"logo_v2"`
 	IsCompletable bool   `json:"is_completable"`
 	IsReplyable   bool   `json:"is_replyable"`
 }
@@ -373,6 +374,7 @@ func (api *API) taskBaseToTaskResult(t *database.Item) *TaskResult {
 		Source: TaskSource{
 			Name:          taskSourceResult.Details.Name,
 			Logo:          taskSourceResult.Details.Logo,
+			LogoV2:        taskSourceResult.Details.LogoV2,
 			IsCompletable: taskSourceResult.Details.IsCompletable,
 			IsReplyable:   taskSourceResult.Details.IsReplyable,
 		},

--- a/backend/external/config.go
+++ b/backend/external/config.go
@@ -238,6 +238,7 @@ type TaskSourceDetails struct {
 	ID            string
 	Name          string
 	Logo          string
+	LogoV2        string
 	IsCompletable bool
 	IsCreatable   bool
 	IsReplyable   bool
@@ -247,6 +248,7 @@ var TaskSourceGeneralTask = TaskSourceDetails{
 	ID:            TASK_SOURCE_ID_GT_TASK,
 	Name:          "General Task",
 	Logo:          "/images/generaltask.svg",
+	LogoV2:        "generaltask",
 	IsCompletable: true,
 	IsCreatable:   true,
 	IsReplyable:   false,
@@ -255,6 +257,7 @@ var TaskSourceGoogleCalendar = TaskSourceDetails{
 	ID:            TASK_SOURCE_ID_GCAL,
 	Name:          "Google Calendar",
 	Logo:          "/images/gcal.svg",
+	LogoV2:        "gcal",
 	IsCompletable: false,
 	IsCreatable:   false,
 	IsReplyable:   false,
@@ -263,6 +266,7 @@ var TaskSourceGithubPR = TaskSourceDetails{
 	ID:            TASK_SOURCE_ID_GITHUB_PR,
 	Name:          "Git PR",
 	Logo:          "/images/github.svg",
+	LogoV2:        "github",
 	IsCompletable: false,
 	IsCreatable:   false,
 	IsReplyable:   false,
@@ -271,6 +275,7 @@ var TaskSourceGmail = TaskSourceDetails{
 	ID:            TASK_SOURCE_ID_GMAIL,
 	Name:          "Gmail",
 	Logo:          "/images/gmail.svg",
+	LogoV2:        "gmail",
 	IsCompletable: true,
 	IsCreatable:   false,
 	IsReplyable:   true,
@@ -279,6 +284,7 @@ var TaskSourceJIRA = TaskSourceDetails{
 	ID:            TASK_SOURCE_ID_JIRA,
 	Name:          "Jira",
 	Logo:          "/images/jira.svg",
+	LogoV2:        "jira",
 	IsCompletable: true,
 	IsCreatable:   false,
 	IsReplyable:   false,
@@ -287,6 +293,7 @@ var TaskSourceAsana = TaskSourceDetails{
 	ID:            TASK_SOURCE_ID_ASANA,
 	Name:          "Asana",
 	Logo:          "/images/asana.svg",
+	LogoV2:        "asana",
 	IsCompletable: true,
 	IsCreatable:   false,
 	IsReplyable:   false,


### PR DESCRIPTION
With the react native frontend we can't dynamically set asset images, so providing a relative path to a
logo will not work. Instead we can pass the name of the logo and match it to an imported asset.