### PR TITLE
Switch senderV2 struct from bson to json in messages_list serializer

### DIFF
--- a/backend/api/messages_list.go
+++ b/backend/api/messages_list.go
@@ -13,15 +13,15 @@ type messageSource struct {
 	AccountId     string `json:"account_id"`
 	Name          string `json:"name"`
 	Logo          string `json:"logo"`
-	LogoV2          string `json:"logo_v2"`
+	LogoV2        string `json:"logo_v2"`
 	IsCompletable bool   `json:"is_completable"`
 	IsReplyable   bool   `json:"is_replyable"`
 }
 
 type senderV2 struct {
-	Name    string `bson:"name"`
-	Email   string `bson:"email"`
-	ReplyTo string `bson:"reply_to"`
+	Name    string `json:"name"`
+	Email   string `json:"email"`
+	ReplyTo string `json:"reply_to"`
 }
 
 type message struct {
@@ -89,12 +89,12 @@ func (api *API) emailToMessage(e *database.Item) *message {
 		},
 		SentAt:   e.CreatedAtExternal.Time().Format(time.RFC3339),
 		IsUnread: e.Email.IsUnread,
-		IsTask: e.TaskType.IsTask,
+		IsTask:   e.TaskType.IsTask,
 		Source: messageSource{
 			AccountId:     e.SourceAccountID,
 			Name:          messageSourceResult.Details.Name,
 			Logo:          messageSourceResult.Details.Logo,
-			LogoV2:          messageSourceResult.Details.LogoV2,
+			LogoV2:        messageSourceResult.Details.LogoV2,
 			IsCompletable: messageSourceResult.Details.IsCreatable,
 			IsReplyable:   messageSourceResult.Details.IsReplyable,
 		},


### PR DESCRIPTION
Backend was previously outputting capitalized letters in json (`{"Name": "Scott",  "Email": "...}`)

Switched `bson` to `json` - think this was intended?