### PR TITLE
Minor changes to calendar header to match Figma

### DIFF
--- a/frontend/src/components/calendar/CalendarHeader.tsx
+++ b/frontend/src/components/calendar/CalendarHeader.tsx
@@ -26,7 +26,7 @@ const ButtonStyles = styled.button`
     width: fit-content;
     border: none;
     border-radius: 50vh;
-    padding: ${Spacing.padding.xSmall}px ${Spacing.padding.small}px;
+    padding: 0px;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -34,14 +34,16 @@ const ButtonStyles = styled.button`
 export const HoverButton = styled(ButtonStyles)`
     color: ${Colors.white};
     background-color: ${Colors.purple._1};
+    padding: ${Spacing.padding.xSmall}px ${Spacing.padding.small}px;
     &:hover {
         background-color: ${Colors.purple._2};
     }
 `
 export const ArrowButton = styled(ButtonStyles)`
     background-color: inherit;
+    padding: ${Spacing.padding.xSmall}px;
     &:hover {
-        background-color: ${Colors.gray._200}} 
+        background-color: ${Colors.gray._200};
     }
 `
 


### PR DESCRIPTION
@jreinstra I would like some feedback on what you would like changed for the calendar header. Right now it doesn't perfectly match figma, mostly because our calendar width was made smaller, and we don't have all the buttons that figma has because we haven't implemented that functionality yet.

For reference, this is what this PR makes the header look like: 
<img width="309" alt="Screen Shot 2022-03-29 at 3 39 04 PM" src="https://user-images.githubusercontent.com/31417618/160718351-44ede11c-2c85-4831-b71f-81b3648597ec.png">

And this is what Figma looks like:
<img width="727" alt="Screen Shot 2022-03-29 at 3 39 24 PM" src="https://user-images.githubusercontent.com/31417618/160718393-748e3027-3f4f-4ffb-b8ca-d8c973ba5890.png">

