### PR TITLE
Fix TimeIndicator with useInterval 

### DIFF
--- a/frontend/src/components/calendar/TimeIndicator.tsx
+++ b/frontend/src/components/calendar/TimeIndicator.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useCallback, useState } from 'react'
 
 import { CELL_HEIGHT } from './CalendarEvents-styles'
 import { Colors } from '../../styles'
@@ -20,7 +20,7 @@ const TimeIndicatorContainer = styled.div<TimeIndicatorContainerProps>`
 
 export function TimeIndicator(): JSX.Element {
     const [time, setTime] = useState(DateTime.now())
-    useInterval(() => setTime(DateTime.now()), TIME_INDICATOR_INTERVAL)
+    useInterval(useCallback(() => setTime(DateTime.now()), []), TIME_INDICATOR_INTERVAL)
 
     const topOffset = (60 * time.hour + time.minute) * (CELL_HEIGHT / 60)
     return <TimeIndicatorContainer topOffset={topOffset} />


### PR DESCRIPTION
Added a `useCallback` since TimeIndicator was rapidly re-rendering when using `useInterval`