### PR TITLE
Fix drag-n-drop bug

### DIFF
--- a/frontend/src/components/molecules/TaskDropContainer.tsx
+++ b/frontend/src/components/molecules/TaskDropContainer.tsx
@@ -18,12 +18,15 @@ const DropIndicatorStyles = css<{ isVisible: boolean }>`
     width: 100%;
     background-color: ${Colors.gray._800};
     visibility: ${(props) => (props.isVisible ? 'visible' : 'hidden')};
+    position: relative;
 `
 export const DropIndicatorAbove = styled.div`
     ${DropIndicatorStyles}
+    top: -0.5px;
 `
 export const DropIndicatorBelow = styled.div`
     ${DropIndicatorStyles}
+    top: 0.5px;
 `
 
 interface TaskDropContainerProps {


### PR DESCRIPTION
- Fixed bug where drop indicators were only appearing above tasks
- Fixed styling so that indicator appears the same between two tasks when hovering over either the top or bottom task