### PR TITLE
Move DND Provider to improve landing page performance

### DIFF
--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -2,8 +2,6 @@ import { BrowserRouter, Navigate, Outlet, Route, Routes } from 'react-router-dom
 import { QueryClient, QueryClientProvider } from 'react-query'
 import React, { Suspense, lazy } from 'react'
 
-import { DndProvider } from 'react-dnd'
-import { HTML5Backend } from 'react-dnd-html5-backend'
 import LandingScreen from './src/screens/LandingScreen'
 import Loading from './src/components/atoms/Loading'
 import PrivateOutlet from './src/services/PrivateOutlet'
@@ -30,36 +28,34 @@ const App = () => {
     return (
         <QueryClientProvider client={queryClient}>
             <Provider store={store}>
-                <DndProvider backend={HTML5Backend}>
-                    <BrowserRouter>
-                        <Suspense fallback={<Loading />}>
-                            <Routes>
-                                <Route path="*" element={<Navigate to="/" />} />
-                                <Route path="/" element={<Outlet />}>
-                                    <Route index element={<LandingScreen />} />
-                                    <Route path="terms-of-service" element={<CompanyPolicyScreen />} />
-                                    <Route path="privacy-policy" element={<CompanyPolicyScreen />} />
-                                    <Route path="tos-summary" element={<PrivateOutlet />}>
-                                        <Route index element={<TermsOfServiceSummaryScreen />} />
-                                    </Route>
-                                    <Route path="tasks" element={<PrivateOutlet />}>
-                                        <Route index element={<TasksScreen />} />
-                                        <Route path=":section" element={<TasksScreen />}>
-                                            <Route path=":task" element={<TasksScreen />} />
-                                        </Route>
-                                    </Route>
-                                    <Route path="messages" element={<PrivateOutlet />}>
-                                        <Route index element={<TasksScreen />} />
-                                        <Route path=":message" element={<TasksScreen />} />
-                                    </Route>
-                                    <Route path="settings" element={<PrivateOutlet />}>
-                                        <Route index element={<TasksScreen />} />
+                <BrowserRouter>
+                    <Suspense fallback={<Loading />}>
+                        <Routes>
+                            <Route path="*" element={<Navigate to="/" />} />
+                            <Route path="/" element={<Outlet />}>
+                                <Route index element={<LandingScreen />} />
+                                <Route path="terms-of-service" element={<CompanyPolicyScreen />} />
+                                <Route path="privacy-policy" element={<CompanyPolicyScreen />} />
+                                <Route path="tos-summary" element={<PrivateOutlet />}>
+                                    <Route index element={<TermsOfServiceSummaryScreen />} />
+                                </Route>
+                                <Route path="tasks" element={<PrivateOutlet />}>
+                                    <Route index element={<TasksScreen />} />
+                                    <Route path=":section" element={<TasksScreen />}>
+                                        <Route path=":task" element={<TasksScreen />} />
                                     </Route>
                                 </Route>
-                            </Routes>
-                        </Suspense>
-                    </BrowserRouter>
-                </DndProvider>
+                                <Route path="messages" element={<PrivateOutlet />}>
+                                    <Route index element={<TasksScreen />} />
+                                    <Route path=":message" element={<TasksScreen />} />
+                                </Route>
+                                <Route path="settings" element={<PrivateOutlet />}>
+                                    <Route index element={<TasksScreen />} />
+                                </Route>
+                            </Route>
+                        </Routes>
+                    </Suspense>
+                </BrowserRouter>
             </Provider>
         </QueryClientProvider>
     )

--- a/frontend/src/screens/TasksScreen.tsx
+++ b/frontend/src/screens/TasksScreen.tsx
@@ -1,8 +1,11 @@
 import { Navigate, useLocation, useParams } from 'react-router-dom'
 import React, { useEffect } from 'react'
 import { useGetTasks, useGetUserInfo } from '../services/api-query-hooks'
+
 import CalendarView from '../components/views/CalendarView'
 import DefaultTemplate from '../components/templates/DefaultTemplate'
+import { DndProvider } from 'react-dnd'
+import { HTML5Backend } from 'react-dnd-html5-backend'
 import Loading from '../components/atoms/Loading'
 import Messages from '../components/views/MessagesView'
 import Settings from '../components/views/SettingsView'
@@ -41,12 +44,14 @@ const TasksScreen = () => {
     if (!isTaskSectionsLoading && !userInfo.agreed_to_terms) return <Navigate to="/tos-summary" />
 
     return (
-        <DefaultTemplate>
-            <>
-                {currentPage}
-                <CalendarView />
-            </>
-        </DefaultTemplate>
+        <DndProvider backend={HTML5Backend}>
+            <DefaultTemplate>
+                <>
+                    {currentPage}
+                    <CalendarView />
+                </>
+            </DefaultTemplate>
+        </DndProvider>
     )
 }
 


### PR DESCRIPTION
web.dev identified the HTML5Backend for react-dnd as a large part of unused javascript on the landing page, so I moved it and the dnd provider into `TasksScreen` since it is only used in there anyways