### PR TITLE
box shadow for calendarevents was too harsh

### DIFF
--- a/frontend/src/components/calendar/CalendarEvents-styles.tsx
+++ b/frontend/src/components/calendar/CalendarEvents-styles.tsx
@@ -109,7 +109,7 @@ export const EventFill = styled.div<{ squareStart: boolean, squareEnd: boolean }
     background: ${Colors.white};
     border: 1px solid ${EVENT_CONTAINER_COLOR};
     box-sizing: border-box;
-    box-shadow: ${Shadows.xLarge};
+    box-shadow: ${Shadows.small};
     border-top-left-radius: ${(props) => (props.squareStart ? '0' : '10px')};
     border-top-right-radius: ${(props) => (props.squareStart ? '0' : '10px')};
     border-bottom-left-radius: ${(props) => (props.squareEnd ? '0' : '10px')};


### PR DESCRIPTION
old:
<img width="292" alt="Screen Shot 2022-04-05 at 9 44 16 AM" src="https://user-images.githubusercontent.com/9156543/161804605-abbb0eea-00f3-4684-8944-fe962797787b.png">

new:
<img width="275" alt="Screen Shot 2022-04-05 at 9 44 37 AM" src="https://user-images.githubusercontent.com/9156543/161804700-527b4731-b231-49c8-8772-f070acb41962.png">

