### PR TITLE
memoize calendar view and refetch calendar events very 60 seconds

### DIFF
--- a/frontend/src/components/views/CalendarView.tsx
+++ b/frontend/src/components/views/CalendarView.tsx
@@ -17,4 +17,4 @@ const CalendarView = () => {
     )
 }
 
-export default CalendarView
+export default React.memo(CalendarView)

--- a/frontend/src/screens/TasksScreen.tsx
+++ b/frontend/src/screens/TasksScreen.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect } from 'react'
-import { useMemo } from 'react'
 import { DndProvider } from 'react-dnd'
 import { HTML5Backend } from 'react-dnd-html5-backend'
 import { Navigate, useLocation, useParams } from 'react-router-dom'
@@ -14,7 +13,6 @@ import { setSelectedItemId } from '../redux/tasksPageSlice'
 import { useGetTasks, useGetUserInfo } from '../services/api-query-hooks'
 
 const TasksScreen = () => {
-    const memoizedCalendar = useMemo(() => <CalendarView />, [])
     const expandedCalendar = useAppSelector((state) => state.tasks_page.expanded_calendar)
     const location = useLocation()
     const dispatch = useAppDispatch()
@@ -50,7 +48,7 @@ const TasksScreen = () => {
             <DefaultTemplate>
                 <>
                     {expandedCalendar || currentPage}
-                    {memoizedCalendar}
+                    <CalendarView />
                 </>
             </DefaultTemplate>
         </DndProvider>


### PR DESCRIPTION
In a future PR we'll probably want to make a custom hook for this re-fetching logic