### PR TITLE
Make styled components way better 

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -82,6 +82,7 @@
     "style-loader": "^3.3.1",
     "ts-loader": "^9.2.8",
     "typescript": "~4.3.5",
+    "typescript-plugin-styled-components": "^2.0.0",
     "webpack": "^5.71.0",
     "webpack-cli": "^4.9.2",
     "webpack-dev-server": "^4.8.1"

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -1,9 +1,11 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 /* eslint-disable no-undef */
 const path = require('path');
-const HtmlWebpackPlugin = require('html-webpack-plugin');
+const HtmlWebpackPlugin = require('html-webpack-plugin')
 const CopyWebpackPlugin = require('copy-webpack-plugin')
+const createStyledComponentsTransformer = require('typescript-plugin-styled-components').default;
 
+const styledComponentsTransformer = createStyledComponentsTransformer();
 const host = process.env.HOST || 'localhost';
 
 // Required for babel-preset-react-app
@@ -15,15 +17,18 @@ module.exports = {
         rules: [
             {
                 test: /\.ts$|tsx/,
-                use: ["ts-loader"],
+                use: {
+                    loader: 'ts-loader',
+                    options: {
+                        getCustomTransformers: () => ({ before: [styledComponentsTransformer] })
+                    }
+                },
                 exclude: /node_modules/,
             },
             {
                 test: /\.js$/,
                 exclude: /node_modules/,
-                use: {
-                    loader: "babel-loader"
-                }
+                use: "babel-loader",
             },
             {
                 test: /\.css$/i,

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -8049,6 +8049,11 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
+typescript-plugin-styled-components@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/typescript-plugin-styled-components/-/typescript-plugin-styled-components-2.0.0.tgz#97e94187cca0f3058c6ad8fefffbca6766c56123"
+  integrity sha512-Wu7F96dwuphgiACHfu63vTbRRg6tkPwLnpFJwdxM70Y0PLfeKLRnvs2Yo5MAySMwE120ODMKk9W4TtJgY1ZumA==
+
 typescript@~4.3.5:
   version "4.3.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.5.tgz#4d1c37cc16e893973c45a06886b7113234f119f4"


### PR DESCRIPTION
Before: 
![image](https://user-images.githubusercontent.com/42781446/162551318-b63c7520-ad3b-491e-a9fa-4b9b6c037d9f.png)

After: 
![image](https://user-images.githubusercontent.com/42781446/162551322-04348ff0-cd8c-4684-be45-f81f84f5c455.png)

(display the name of styled components instead of `styled.div`)