### PR TITLE
Adding default plugin directory

### DIFF
--- a/frontend/cypress/plugins/index.ts
+++ b/frontend/cypress/plugins/index.ts
@@ -1,7 +1,7 @@
 /// <reference types="cypress" />
 
 
-module.exports = (_on: Cypress.PluginEvents, _config: Cypress.PluginConfigOptions) => {
+module.exports = () => {
   // `on` is used to hook into various events Cypress emits
   // `config` is the resolved Cypress config
 }


### PR DESCRIPTION
Currently we're not using any plugins, but the directory is required/auto-generated by Cypress on every run