### PR TITLE
create wrapper function for deselecting a task

### DIFF
--- a/frontend/src/components/molecules/TaskDeselectWrapper.tsx
+++ b/frontend/src/components/molecules/TaskDeselectWrapper.tsx
@@ -1,0 +1,32 @@
+import React, { useCallback } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+import styled from 'styled-components'
+import { useAppDispatch } from '../../redux/hooks'
+import { setSelectedItemId } from '../../redux/tasksPageSlice'
+
+const DeselectContainer = styled.div`
+    width: 100%;
+    height: 100%;
+`
+
+const withTaskDeselect = <P extends object>(Component: React.ComponentType<P>) => {
+    const dispatch = useAppDispatch()
+    const navigate = useNavigate()
+    const params = useParams()
+    const hideDetailsView = useCallback(() => navigate(`/tasks/${params.section}`), [params])
+
+    const onClickHandler = () => {
+        dispatch(setSelectedItemId(''))
+        hideDetailsView()
+    }
+
+    return ({ ...props }) => {
+        return (
+            <DeselectContainer onClick={onClickHandler}>
+                <Component {...(props as P)} />
+            </DeselectContainer>
+        )
+    }
+}
+
+export default withTaskDeselect

--- a/frontend/src/components/molecules/task-dnd/TaskDropArea.tsx
+++ b/frontend/src/components/molecules/task-dnd/TaskDropArea.tsx
@@ -5,17 +5,17 @@ import { useReorderTask } from '../../../services/api-query-hooks'
 import { DropProps, ItemTypes } from '../../../utils/types'
 import { DropIndicatorAbove } from '../TaskDropContainer'
 
-const DropAreaContainer = styled.div`
-    flex: 1;
-    min-height: 64px;
+const TaskDropAreaContainer = styled.div`
+    width: 100%;
+    height: max(100%, 64px);
 `
 
-interface DropAreaBelowProps {
+interface TaskDropAreaProps {
     dropIndex: number
     taskSectionId: string
 }
 
-const DropAreaBelow = ({ dropIndex, taskSectionId }: DropAreaBelowProps) => {
+const TaskDropArea = ({ dropIndex, taskSectionId }: TaskDropAreaProps) => {
     const dropRef = useRef<HTMLDivElement>(null)
     const { mutate: reorderTask } = useReorderTask()
 
@@ -46,10 +46,10 @@ const DropAreaBelow = ({ dropIndex, taskSectionId }: DropAreaBelowProps) => {
     }, [dropRef])
 
     return (
-        <DropAreaContainer ref={dropRef}>
+        <TaskDropAreaContainer ref={dropRef}>
             <DropIndicatorAbove isVisible={isOver} />
-        </DropAreaContainer>
+        </TaskDropAreaContainer>
     )
 }
 
-export default DropAreaBelow
+export default TaskDropArea

--- a/frontend/src/components/views/TaskSectionView.tsx
+++ b/frontend/src/components/views/TaskSectionView.tsx
@@ -5,7 +5,7 @@ import { useNavigate, useParams } from 'react-router-dom'
 import { Colors } from '../../styles'
 import CreateNewTask from '../molecules/CreateNewTask'
 import { DateTime } from 'luxon'
-import DropAreaBelow from '../molecules/task-dnd/DropAreaBelow'
+import TaskDropArea from '../molecules/task-dnd/TaskDropArea'
 import EventBanner from '../molecules/EventBanners'
 import Loading from '../atoms/Loading'
 import { SectionHeader } from '../molecules/Header'
@@ -19,6 +19,7 @@ import styled from 'styled-components'
 import { useDispatch } from 'react-redux'
 import { useInterval } from '../../utils/hooks'
 import useItemSelectionController from '../../hooks/useItemSelectionController'
+import withTaskDeselect from '../molecules/TaskDeselectWrapper'
 
 const BannerAndSectionContainer = styled.div`
     display: flex;
@@ -98,6 +99,8 @@ const TaskSection = () => {
         return () => document.removeEventListener('click', listener, true)
     }, [bannerTaskSectionRef, sectionViewRef, params])
 
+    const WithDeselectDropArea = withTaskDeselect(TaskDropArea)
+
     return (
         <>
             <BannerAndSectionContainer ref={bannerTaskSectionRef}>
@@ -133,7 +136,7 @@ const TaskSection = () => {
                                             </TaskDropContainer>
                                         )
                                     })}
-                                    <DropAreaBelow
+                                    <WithDeselectDropArea
                                         dropIndex={currentSection.tasks.length + 1}
                                         taskSectionId={currentSection.id}
                                     />


### PR DESCRIPTION
Previously there was a bug that meant we couldn't click in the drop area to close the details view for tasks. I added a HOC that we can use to wrap components that need to close the details view. This will help prevent redundant code