### PR TITLE
Fixing Event Banner Spacing

### DIFF
--- a/frontend/src/components/molecules/EventBanners.tsx
+++ b/frontend/src/components/molecules/EventBanners.tsx
@@ -43,7 +43,6 @@ const BannerTitleView = styled.div`
     padding: 2px 7px;
     flex-shrink: 1;
     min-width: 0;
-    max-width: 260px;
     overflow: hidden;
     text-overflow: ellipsis;
 `
@@ -54,6 +53,7 @@ const MessageView = styled.div`
     justify-content: center;
     flex-shrink: 1;
     margin-right: ${Spacing.margin._12}px;
+    min-width: 0px;
 `
 const MessageText = styled.span`
     white-space: nowrap;


### PR DESCRIPTION
<img width="618" alt="Screen Shot 2022-04-16 at 10 50 48 PM" src="https://user-images.githubusercontent.com/60069300/163702421-18114bd1-dd70-42a4-8c0f-2676c5f10e42.png">
