### PR TITLE
render emails a little better

### DIFF
--- a/frontend/src/components/atoms/SanitizedHTML.tsx
+++ b/frontend/src/components/atoms/SanitizedHTML.tsx
@@ -1,10 +1,16 @@
 import React from 'react'
 import sanitizeHtml from 'sanitize-html'
+import styled from 'styled-components'
 
-interface TaskHTMLBodyProps {
+const SanitizedHTMLContainer = styled.div`
+    width: 100%;
+    overflow: auto;
+`
+
+interface SanitizedHTMLDivProps {
     dirtyHTML: string
 }
-const TaskHTMLBody = ({ dirtyHTML }: TaskHTMLBodyProps) => {
+const SanitizedHTML = ({ dirtyHTML }: SanitizedHTMLDivProps) => {
     const whitelistedHTMLAttributes: sanitizeHtml.IOptions = {
         allowedAttributes: false,
         allowedTags: sanitizeHtml.defaults.allowedTags.concat(['img', 'a', 'center']),
@@ -16,7 +22,7 @@ const TaskHTMLBody = ({ dirtyHTML }: TaskHTMLBodyProps) => {
         ...whitelistedHTMLAttributes,
         transformTags,
     })
-    return <div dangerouslySetInnerHTML={{ __html: cleanHTML }} />
+    return <SanitizedHTMLContainer dangerouslySetInnerHTML={{ __html: cleanHTML }} />
 }
 
-export default TaskHTMLBody
+export default SanitizedHTML

--- a/frontend/src/components/details/EmailTemplate.tsx
+++ b/frontend/src/components/details/EmailTemplate.tsx
@@ -1,7 +1,7 @@
 import { Colors, Typography } from '../../styles'
 import styled from 'styled-components'
 import React, { useEffect, useState } from 'react'
-import TaskHTMLBody from '../atoms/TaskHTMLBody'
+import SanitizedHTML from '../atoms/SanitizedHTML'
 import { removeHTMLTags } from '../../utils/utils'
 
 const DetailsViewContainer = styled.div`
@@ -67,7 +67,7 @@ const EmailTemplate = (props: DetailsTemplateProps) => {
             </CollapseExpandContainer>
             {isCollapsed || (
                 <BodyContainer>
-                    <TaskHTMLBody dirtyHTML={props.body} />
+                    <SanitizedHTML dirtyHTML={props.body} />
                 </BodyContainer>
             )}
         </DetailsViewContainer>

--- a/frontend/src/components/details/MessageDetails.tsx
+++ b/frontend/src/components/details/MessageDetails.tsx
@@ -4,7 +4,7 @@ import EmailSenderDetails from '../molecules/EmailSenderDetails'
 import { Icon } from '../atoms/Icon'
 import { TMessage } from '../../utils/types'
 import { logos } from '../../styles/images'
-import TaskHTMLBody from '../atoms/TaskHTMLBody'
+import SanitizedHTML from '../atoms/SanitizedHTML'
 
 interface MessageDetailsProps {
     message: TMessage
@@ -15,7 +15,7 @@ const MessageDetails = ({ message }: MessageDetailsProps) => {
             top={<Icon source={logos[message.source.logo_v2]} size="small" />}
             title={<Title>{message.title}</Title>}
             subtitle={<EmailSenderDetails sender={message.sender_v2} recipients={message.recipients} />}
-            body={<TaskHTMLBody dirtyHTML={message.body} />}
+            body={<SanitizedHTML dirtyHTML={message.body} />}
         />
     )
 }

--- a/frontend/src/components/details/TaskDetails.tsx
+++ b/frontend/src/components/details/TaskDetails.tsx
@@ -7,7 +7,7 @@ import { Icon } from '../atoms/Icon'
 import { DETAILS_SYNC_TIMEOUT, KEYBOARD_SHORTCUTS } from '../../constants'
 import ReactTooltip from 'react-tooltip'
 import { TTask } from '../../utils/types'
-import TaskHTMLBody from '../atoms/TaskHTMLBody'
+import SanitizedHTML from '../atoms/SanitizedHTML'
 import { logos } from '../../styles/images'
 import { useModifyTask } from '../../services/api-query-hooks'
 import RoundedGeneralButton from '../atoms/buttons/RoundedGeneralButton'
@@ -142,7 +142,7 @@ const TaskDetails = (props: TaskDetailsProps) => {
             }
             body={
                 task.source.name === 'Gmail' ? (
-                    <TaskHTMLBody dirtyHTML={bodyInput} />
+                    <SanitizedHTML dirtyHTML={bodyInput} />
                 ) : (
                     <BodyTextArea
                         ref={bodyRef}


### PR DESCRIPTION
Set outermost div for email rendering to allow for scrolling, and have the div be the maximum possible width.
Also renamed TaskHTMLBody component to SanitizedHTML. This was to remove naming confusion with our email body and the <body> html tag.