### PR TITLE
Add common test utils to make testing API a bit easier

### DIFF
--- a/backend/api/meeting_banner_test.go
+++ b/backend/api/meeting_banner_test.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"github.com/GeneralTask/task-manager/backend/testutils"
 	"net/http"
 	"testing"
 
@@ -11,9 +10,9 @@ import (
 func TestMeetingBanner(t *testing.T) {
 	authToken := login("approved@generaltask.com", "")
 
-	testutils.UnauthorizedTest(t, "GET", "/meeting_banner/", nil)
+	UnauthorizedTest(t, "GET", "/meeting_banner/", nil)
 	t.Run("Success", func(t *testing.T) {
-		body := testutils.ServeRequest(t, authToken, "GET", "/meeting_banner/", nil, http.StatusOK)
+		body := ServeRequest(t, authToken, "GET", "/meeting_banner/", nil, http.StatusOK)
 		assert.Equal(t, "{\"title\":\"Your next meeting is at 4:20pm\",\"subtitle\":\"It looks like you've got a little time before your next meeting (6.9 min)\",\"events\":[{\"title\":\"Blast off\",\"meeting_link\":\"https://www.youtube.com/watch?v=dQw4w9WgXcQ\"}],\"actions\":[{\"logo\":\"github\",\"title\":\"Review PR: Email reply v0\",\"link\":\"https://github.com/GeneralTask/task-manager/pull/1027\"}]}", string(body))
 	})
 }

--- a/backend/testutils/utils.go
+++ b/backend/testutils/utils.go
@@ -1,14 +1,7 @@
 package testutils
 
 import (
-	"github.com/GeneralTask/task-manager/backend/api"
-	"github.com/stretchr/testify/assert"
 	"go.mongodb.org/mongo-driver/bson/primitive"
-	"io"
-	"io/ioutil"
-	"net/http"
-	"net/http/httptest"
-	"testing"
 	"time"
 )
 
@@ -20,35 +13,4 @@ func CreateTimestamp(dt string) *time.Time {
 func CreateDateTime(dt string) *primitive.DateTime {
 	res := primitive.NewDateTimeFromTime(*CreateTimestamp(dt))
 	return &res
-}
-
-func ServeRequest(
-	t *testing.T,
-	authToken string,
-	method string,
-	url string,
-	requestBody io.Reader,
-	expectedReponseCode int,
-) []byte {
-	router := api.GetRouter(api.GetAPI())
-	request, _ := http.NewRequest(method, url, requestBody)
-	request.Header.Add("Authorization", "Bearer "+authToken)
-
-	recorder := httptest.NewRecorder()
-	router.ServeHTTP(recorder, request)
-	assert.Equal(t, expectedReponseCode, recorder.Code)
-	responseBody, err := ioutil.ReadAll(recorder.Body)
-	assert.NoError(t, err)
-	return responseBody
-}
-
-func UnauthorizedTest(t *testing.T, method string, url string, body io.Reader) bool {
-	return t.Run("Unauthorized", func(t *testing.T) {
-		router := api.GetRouter(api.GetAPI())
-		request, _ := http.NewRequest(method, url, body)
-
-		recorder := httptest.NewRecorder()
-		router.ServeHTTP(recorder, request)
-		assert.Equal(t, http.StatusUnauthorized, recorder.Code)
-	})
 }


### PR DESCRIPTION
Curious to hear your thoughts about this.. Seems quite nice for API endpoint testing, but maybe it's just overengineering

I'll migrate other testings in a followup diff if this is helpful