### PR TITLE
Add min-width on settings page buttons

### DIFF
--- a/frontend/src/components/views/MessagesView.tsx
+++ b/frontend/src/components/views/MessagesView.tsx
@@ -9,6 +9,7 @@ import Thread from '../molecules/Thread'
 import ThreadDetails from '../details/ThreadDetails'
 import { Border, Colors, Spacing } from '../../styles'
 import ThreadTemplate from '../atoms/ThreadTemplate'
+import { DEFAULT_VIEW_WIDTH } from '../../styles/dimensions'
 
 const ScrollViewMimic = styled.div`
     margin: 40px 0px 0px 10px;
@@ -21,7 +22,7 @@ const ScrollViewMimic = styled.div`
 const MessagesContainer = styled.div`
     border-radius: ${Border.radius.large};
     background-color: ${Colors.gray._100};
-    width: 480px;
+    width: ${DEFAULT_VIEW_WIDTH};
 `
 const MessageDivider = styled.div`
     border-bottom: 1px solid ${Colors.gray._200};

--- a/frontend/src/components/views/SettingsView.tsx
+++ b/frontend/src/components/views/SettingsView.tsx
@@ -7,6 +7,7 @@ import { Icon } from '../atoms/Icon'
 import { SectionHeader } from '../molecules/Header'
 import TaskTemplate from '../atoms/TaskTemplate'
 import { logos } from '../../styles/images'
+import { DEFAULT_VIEW_WIDTH } from '../../styles/dimensions'
 
 const AUTH_WINDOW_WIDTH = 960
 const AUTH_WINDOW_HEIGHT = 640
@@ -16,7 +17,7 @@ const ScrollViewMimic = styled.div`
 `
 const SettingsViewContainer = styled.div`
     font-family: Switzer-Variable;
-    min-width: 400px;
+    min-width: ${DEFAULT_VIEW_WIDTH};
 `
 const AccountsContainer = styled.div`
     margin-top: ${Spacing.margin._16}px;

--- a/frontend/src/components/views/TaskSectionView.tsx
+++ b/frontend/src/components/views/TaskSectionView.tsx
@@ -15,6 +15,7 @@ import { getSectionById } from '../../utils/task'
 import styled from 'styled-components'
 import useItemSelectionController from '../../hooks/useItemSelectionController'
 import TaskDropArea from '../molecules/task-dnd/TaskDropArea'
+import { DEFAULT_VIEW_WIDTH } from '../../styles/dimensions'
 
 const BannerAndSectionContainer = styled.div`
     display: flex;
@@ -35,7 +36,7 @@ const TaskSectionViewContainer = styled.div`
     flex-direction: column;
     padding-top: 0;
     background-color: ${Colors.gray._50};
-    width: 480px;
+    width: ${DEFAULT_VIEW_WIDTH};
 `
 const TasksContainer = styled.div`
     display: flex;

--- a/frontend/src/styles/dimensions.ts
+++ b/frontend/src/styles/dimensions.ts
@@ -19,5 +19,6 @@ export const modalSize = {
 
 export const COLLAPSED_CALENDAR_WIDTH = 40;
 export const TASK_ACTION_WIDTH = '200px'
+export const DEFAULT_VIEW_WIDTH = '480px'
 export const TASK_DEFAULT_LINE_HEIGHT = 17;
 export const INPUT_VARIABLE_DEFAULT_LINE_HEIGHT = 31;


### PR DESCRIPTION
After:
<img width="316" alt="Screen Shot 2022-05-04 at 4 24 24 PM" src="https://user-images.githubusercontent.com/31417618/166841035-fd58c6c5-9be9-4bb2-8ee3-2eefe8cae28e.png">

Before:
![Screenshot 2022-05-04 at 16-25-12 FRO-149 Buttons become multi-line on Settings page when width is too low](https://user-images.githubusercontent.com/31417618/166841149-7fb6e24c-8b6b-4e31-8de9-8133c709d7f4.png)

