### PR TITLE
Remove extra spacing from CC/BCC buttons

### DIFF
--- a/frontend/src/components/details/EmailCompose/EmailCompose-styles.ts
+++ b/frontend/src/components/details/EmailCompose/EmailCompose-styles.ts
@@ -87,9 +87,9 @@ export const BodyContainer = styled.div`
 `
 export const AddEmailRecipientsContainer = styled.div`
     display: flex;
-    align-items: end;
+    align-items: center;
     margin-left: auto;
-    padding: ${Spacing.padding._8}px;
+    padding: 0 ${Spacing.padding._8}px;
     gap: ${Spacing.margin._4}px;
 `
 export const AddEmailRecipientsButton = styled(NoStyleButton)`


### PR DESCRIPTION
Before:
<img width="753" alt="image" src="https://user-images.githubusercontent.com/42781446/166850115-28207529-30a0-4813-bac4-a1f2012be244.png">

After:
<img width="760" alt="image" src="https://user-images.githubusercontent.com/42781446/166850135-2b6dacde-7ce1-45ea-a77a-12a652c51d88.png">
