### PR TITLE
Mark task as done test error which shouldn't happen, but does

### DIFF
--- a/frontend/cypress/integration/mark-task-done.ts
+++ b/frontend/cypress/integration/mark-task-done.ts
@@ -16,7 +16,7 @@ describe('user can mark as task as done', () => {
             cy.get('button').find('img').should('have.attr', 'src', '/images/task_complete.png')
         })
         cy.wait('@markTaskDoneMutation').then(({ response }) => {
-            expect(response.statusCode).to.eq(200)
+            expect(response?.statusCode).to.eq(200)
         })
     })
     it('task appears in done section', () => {


### PR DESCRIPTION
<img width="685" alt="Screen Shot 2022-05-06 at 11 52 45 AM" src="https://user-images.githubusercontent.com/31417618/167200288-bf1adcdc-5744-424e-a633-0c3ab4ca8447.png">
