### PR TITLE
Fix section header buttons not showing with long title

### DIFF
--- a/frontend/src/components/molecules/Header.tsx
+++ b/frontend/src/components/molecules/Header.tsx
@@ -88,7 +88,7 @@ export const SectionHeader = (props: SectionHeaderProps) => {
         <HeaderTextEditable
             ref={sectionTitleRef}
             value={sectionName}
-            onChange={(e) => setSectionName(e.target.value.trim().substring(0, 200))}
+            onChange={(e) => setSectionName(e.target.value.substring(0, 200))}
             onKeyDown={handleKeyDown}
             onBlur={() => handleChangeSectionName(props.taskSectionId, sectionName)}
             autoFocus


### PR DESCRIPTION
**Edit: added 200 character limit to title**

Made section title wrap when very long.

Before:
<img width="392" alt="image" src="https://user-images.githubusercontent.com/42781446/169487557-60d036a7-fef8-42d9-9239-81f9286f3bcf.png">

After:
<img width="389" alt="image" src="https://user-images.githubusercontent.com/42781446/169487617-8fc23019-da5e-41de-8c6a-c81788ba749b.png">

This took a long time to figure out lol