### PR TITLE
Make email list slightly more compact

### DIFF
--- a/frontend/src/components/atoms/ThreadTemplate.tsx
+++ b/frontend/src/components/atoms/ThreadTemplate.tsx
@@ -6,7 +6,7 @@ import { TASK_DEFAULT_LINE_HEIGHT } from '../../styles/dimensions'
 const TemplateContainer = styled.div`
     width: 100%;
     position: relative;
-    height: ${TASK_DEFAULT_LINE_HEIGHT * 5}px;
+    height: ${TASK_DEFAULT_LINE_HEIGHT * 4}px;
     border-radius: ${Border.radius.large};
     padding: 1px 0;
 `


### PR DESCRIPTION
I think it looks a bit more consistent with our task list and is a bit more practical this way.

<img width="904" alt="image" src="https://user-images.githubusercontent.com/4002306/171287107-9447fa90-dd95-4474-b9c1-bd0cc2257977.png">
