### PR TITLE
Generate random IDs for optimistically created tasks

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -45,7 +45,8 @@
     "react-toastify": "^9.0.1",
     "react-tooltip": "^4.2.21",
     "sanitize-html": "^2.7.0",
-    "styled-components": "^5.3.3"
+    "styled-components": "^5.3.3",
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
     "@babel/core": "^7.17.8",
@@ -67,6 +68,7 @@
     "@types/react-native": "~0.64.12",
     "@types/sanitize-html": "^2.6.2",
     "@types/styled-components": "^5.1.24",
+    "@types/uuid": "^8.3.4",
     "@typescript-eslint/eslint-plugin": "^5.14.0",
     "@typescript-eslint/parser": "^5.14.0",
     "babel-jest": "^27.5.1",

--- a/frontend/src/services/api-query-hooks.ts
+++ b/frontend/src/services/api-query-hooks.ts
@@ -35,6 +35,7 @@ import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from 'react-q
 import { DateTime } from 'luxon'
 import apiClient from '../utils/api'
 import { getMonthsAroundDate } from '../utils/time'
+import { v4 as uuidv4 } from 'uuid'
 
 /**
  * TASKS QUERIES
@@ -89,12 +90,11 @@ export const useCreateTask = () => {
 
             const sections: TTaskSection[] | undefined = queryClient.getQueryData('tasks')
             if (!sections) return
-            console.log(window.crypto.randomUUID())
 
             for (const section of sections) {
                 if (section.id === data.id_task_section) {
                     const newTask: TTask = {
-                        id: window.crypto.randomUUID(),
+                        id: uuidv4(),
                         id_ordering: 0,
                         title: data.title,
                         body: data.body,

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1879,6 +1879,11 @@
     "@types/react" "*"
     csstype "^3.0.2"
 
+"@types/uuid@^8.3.4":
+  version "8.3.4"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.4.tgz#bd86a43617df0594787d38b735f55c805becf1bc"
+  integrity sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==
+
 "@types/ws@^8.5.1":
   version "8.5.3"
   resolved "https://registry.yarnpkg.com/@types/ws/-/ws-8.5.3.tgz#7d25a1ffbecd3c4f2d35068d0b283c037003274d"


### PR DESCRIPTION
Should fix some weirdness around optimistic task creation, and resolve error about duplicate keys