### PR TITLE
Don't autoscroll to the last message in the thread

### DIFF
--- a/frontend/src/components/details/email/EmailContainer.tsx
+++ b/frontend/src/components/details/email/EmailContainer.tsx
@@ -1,5 +1,5 @@
 import { Colors, Spacing, Typography } from '../../../styles'
-import React, { useEffect, useLayoutEffect, useRef, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { TEmail, TEmailComposeState } from '../../../utils/types'
 import { getHumanDateTime, removeHTMLTags } from '../../../utils/utils'
 
@@ -88,22 +88,14 @@ interface EmailContainerProps {
 const EmailContainer = (props: EmailContainerProps) => {
     const [isCollapsed, setIsCollapsed] = useState(!props.isLastThread)
     const timeSent = getHumanDateTime(DateTime.fromISO(props.email.sent_at))
-    const scrollingRef = useRef<HTMLDivElement>(null)
 
     useEffect(() => {
         ReactTooltip.hide()
         ReactTooltip.rebuild()
     }, [isCollapsed])
 
-    useLayoutEffect(() => {
-        setIsCollapsed(!props.isLastThread)
-        if (props.isLastThread) {
-            scrollingRef.current?.scrollIntoView()
-        }
-    }, [props.isLastThread])
-
     return (
-        <DetailsViewContainer ref={scrollingRef}>
+        <DetailsViewContainer>
             <CollapseExpandContainer onClick={() => setIsCollapsed(!isCollapsed)}>
                 <SenderContainer>
                     <div>


### PR DESCRIPTION
You can now see previous messages when opening a thread. They're still auto-collapsed so it doesn't take away too much screen real estate. I think this is a good change 👍 