### PR TITLE
Reply to other recipients of email if the user is the sender

### DIFF
--- a/frontend/src/components/details/email/compose/utils.ts
+++ b/frontend/src/components/details/email/compose/utils.ts
@@ -37,7 +37,7 @@ export function getInitialRecipients(email: TEmail, composeType: EmailComposeTyp
         else if (composeType === EmailComposeType.REPLY_ALL) {
             return {
                 to: email.recipients.to,
-                cc: email.recipients.cc,
+                cc: email.recipients.cc.filter(r => r.email !== userEmail),
                 bcc: []
             }
         }


### PR DESCRIPTION
Previously, if you tried to reply to your own email, you (the sender) would the only recipient. This adjust the behavior to better match Gmail when you are the sender of an email.

Reply and Reply all functionality differs if the sender of an email is the user.
- For reply, all of the recipients of the email become the to recipients of the response. Does include the user.
- For reply all, the CC recipients also become CC recipients of the response. Does not include the user.
- Email is wack

Given an email with these recipients:
![image](https://user-images.githubusercontent.com/42781446/173131964-9dff2405-1a22-4924-bad1-c40e6d4da792.png)

peep this fancy table:

(also Imma Farma is the name on `maiscottie@gmail.com` don't ask why I was 13)

| Email Type     | Gmail defaults | new General Task defaults 😎|
| -------------  | -------------  | ------------- |
| Reply          | ![image](https://user-images.githubusercontent.com/42781446/173132016-2779c334-79bc-42e9-a3f6-a20ff14ebf2d.png)   | ![image](https://user-images.githubusercontent.com/42781446/173132101-c240b29a-571a-449d-b737-8fe2206522b2.png)  |
| Reply All      | ![image](https://user-images.githubusercontent.com/42781446/173132172-ae0c227c-6328-47d8-8f32-b77b0742db9d.png)   | ![image](https://user-images.githubusercontent.com/42781446/173132285-91d53586-21d2-4d89-a9c0-2a4870511621.png)  |

Also fixed a fairly major bug where the reply/reply all/forward selector was replying to the wrong email