### PR TITLE
Add tooltips to thread header buttons

### DIFF
--- a/frontend/src/components/details/ThreadDetails.tsx
+++ b/frontend/src/components/details/ThreadDetails.tsx
@@ -17,6 +17,8 @@ import TooltipWrapper from '../atoms/TooltipWrapper'
 import ReactTooltip from 'react-tooltip'
 
 const THREAD_HEADER_HEIGHT = '118px'
+const MARK_AS_READ = 'Mark as Read'
+const MARK_AS_UNREAD = 'Mark as Unread'
 
 const FlexColumnContainer = styled.div`
     flex: 1;
@@ -139,7 +141,7 @@ const ThreadDetails = ({ thread }: ThreadDetailsProps) => {
                         <Icon source={icons.message_to_task} size="small" />
                     </NoStyleButton>
                 </TooltipWrapper>
-                <TooltipWrapper inline dataTip={isUnread ? 'Mark as Read' : 'Mark as Unread'} tooltipId="tooltip">
+                <TooltipWrapper inline dataTip={isUnread ? MARK_AS_READ : MARK_AS_UNREAD} tooltipId="tooltip">
                     <NoStyleButton onClick={onClickMarkAsRead}>
                         <Icon source={isUnread ? icons.mark_read : icons.mark_unread} size="small" />
                     </NoStyleButton>


### PR DESCRIPTION
<img width="175" alt="Screen Shot 2022-06-13 at 5 25 17 PM" src="https://user-images.githubusercontent.com/31417618/173468546-5411bb5e-2bca-41e8-95d6-d72b4de68979.png">

Also on the linear task is hover states for these, but I was thinking about this a bit and here's what I've come up with:

The task actions don't have hover states right now so this would be inconsistent with the task page. The other way to do this would be to get designs for 'hovered' icons. These could just be gray versions of the existing icons, but would require some design work.