### PR TITLE
Make the thread header title match the threads list title

### DIFF
--- a/frontend/src/components/details/ThreadDetails.tsx
+++ b/frontend/src/components/details/ThreadDetails.tsx
@@ -73,8 +73,8 @@ const ThreadDetails = ({ thread }: ThreadDetailsProps) => {
         ReactTooltip.rebuild()
     }, [isUnread])
 
-    const threadCountString = thread.emails.length > 1 ? `(${thread.emails.length})` : ''
-    const title = `${threadCountString} ${thread.emails[0]?.subject}`
+    const threadCountString = thread.emails.length > 1 ? `(${thread.emails.length}) ` : ''
+    const title = `${threadCountString}${thread.emails[0]?.subject}`
     const recipient_emails = Array.from(
         new Set(
             thread.emails

--- a/frontend/src/components/molecules/Thread.tsx
+++ b/frontend/src/components/molecules/Thread.tsx
@@ -99,8 +99,8 @@ const Thread = ({ thread, sectionScrollingRef }: ThreadProps) => {
     useKeyboardShortcut('select', onClickHandler, !isSelected)
 
     const senders = thread.emails[0]?.sender.name
-    const threadCountString = thread.emails.length > 1 ? `(${thread.emails.length})` : ''
-    const title = `${threadCountString} ${thread.emails[0]?.subject}`
+    const threadCountString = thread.emails.length > 1 ? `(${thread.emails.length}) ` : ''
+    const title = `${threadCountString}${thread.emails[0]?.subject}`
     const bodytext = thread.emails[thread.emails.length - 1]?.body
     const sentAt = getHumanDateTime(DateTime.fromISO(thread.emails[thread.emails.length - 1]?.sent_at))
     const isUnread = thread.emails.some((email) => email.is_unread)


### PR DESCRIPTION
Before:
<img width="1298" alt="Screen Shot 2022-06-14 at 5 59 11 PM" src="https://user-images.githubusercontent.com/31417618/173714003-91398726-2c91-4bbc-8797-3380ba3d53f5.png">


After:
<img width="1159" alt="Screen Shot 2022-06-14 at 5 58 53 PM" src="https://user-images.githubusercontent.com/31417618/173713976-c72ca010-1278-4bf6-8a4e-38db8f98ebe2.png">

This also means that a "(1)" won't appear next to threads with only one email in them anymore.