### PR TITLE
Fix email reply to wrong email bug

### DIFF
--- a/frontend/src/components/details/email/EmailList.tsx
+++ b/frontend/src/components/details/email/EmailList.tsx
@@ -43,10 +43,9 @@ export const EmailList = ({ thread }: EmailListProps) => {
                                 sourceAccountId={thread.source.account_id}
                             />
                             {composeState.emailId === thread.emails[0].message_id &&
-                                0 !== thread.emails.length - 1 &&
                                 composeState.emailComposeType != null && (
                                     <EmailCompose
-                                        email={thread.emails[thread?.emails.length - 1]}
+                                        email={thread.emails[0]}
                                         composeType={composeState.emailComposeType}
                                         sourceAccountId={thread.source.account_id}
                                         isPending={!!composeState.isPending}
@@ -80,7 +79,7 @@ export const EmailList = ({ thread }: EmailListProps) => {
                                 index !== thread.emails.length - 1 &&
                                 composeState.emailComposeType != null && (
                                     <EmailCompose
-                                        email={thread.emails[thread?.emails.length - 1]}
+                                        email={email}
                                         composeType={composeState.emailComposeType}
                                         sourceAccountId={thread.source.account_id}
                                         isPending={!!composeState.isPending}


### PR DESCRIPTION
Removed from previous PR because the location of this logic changed

Fixes bug where when the user tries to reply to any email in a thread, they actually end up replying to the last email in the thread