### PR TITLE
Fix icon source

### DIFF
--- a/frontend/src/components/atoms/buttons/RoundedGeneralButton.tsx
+++ b/frontend/src/components/atoms/buttons/RoundedGeneralButton.tsx
@@ -2,7 +2,7 @@ import { Border, Colors, Spacing, Typography } from '../../../styles'
 import React from 'react'
 import styled from 'styled-components'
 import { Icon } from '../Icon'
-import { TIconImage } from '../../../styles/images'
+import { icons, TIconImage } from '../../../styles/images'
 
 const RoundedButton = styled.button<{ hasBorder: boolean; textStyle: 'light' | 'dark'; wrapText?: boolean }>`
     display: flex;
@@ -44,7 +44,7 @@ const RoundedGeneralButton = (props: RoundedGeneralButtonProps) => {
             textStyle={props.textStyle || 'light'}
             wrapText={props.wrapText}
         >
-            {props.iconSource && <Icon size="small" source={props.iconSource} />}
+            {props.iconSource && <Icon size="small" source={icons[props.iconSource]} />}
             {props.value}
         </RoundedButton>
     )


### PR DESCRIPTION
Broken icon on external links. Don't know how this happened as it was working in dev before merging
<img width="200" alt="Screen Shot 2022-06-17 at 5 16 45 PM" src="https://user-images.githubusercontent.com/31417618/174414580-086a08dc-118c-4fc9-8ba5-a029adf323a1.png">
