### PR TITLE
Small change to tooltip hide delay

### DIFF
--- a/frontend/src/components/molecules/EmailSenderDetails.tsx
+++ b/frontend/src/components/molecules/EmailSenderDetails.tsx
@@ -70,7 +70,7 @@ const EmailSenderDetails = ({ sender, recipients }: EmailSenderDetailsProps) => 
             .join(', ') + (numRecipients > 3 ? `, +${numRecipients - 3} more` : '')
 
     return (
-        <TooltipWrapper dataTip={details} tooltipId="tooltip">
+        <TooltipWrapper dataTip={details} tooltipId="recipients-tooltip">
             <SmallGrayText>
                 <Underline>{`To: ${displayText}`}</Underline>
             </SmallGrayText>

--- a/frontend/src/components/templates/DefaultTemplate.tsx
+++ b/frontend/src/components/templates/DefaultTemplate.tsx
@@ -41,10 +41,19 @@ const DefaultTemplate = ({ children }: DefaultTemplateProps) => {
     return (
         <DefaultTemplateContainer>
             <ReactTooltip
-                id="tooltip"
+                id="recipients-tooltip"
                 effect="solid"
                 delayShow={250}
                 delayHide={250}
+                delayUpdate={500}
+                className="recipients-tooltip"
+                backgroundColor={Colors.white}
+                textColor={Colors.black}
+            />
+            <ReactTooltip
+                id="tooltip"
+                effect="solid"
+                delayShow={250}
                 delayUpdate={500}
                 className="tooltip"
                 backgroundColor={Colors.white}


### PR DESCRIPTION
Make "normal" tooltips hide immediately. The reason for delaying the "hide" animation of the tooltips was to make sure that the tooltip text was selectable. I added a separate tooltip id for the tooltip for email recipients which you can still select. Now, the tooltips should feel more responsive.

In the future, this gives us flexibility to change the default tooltips easier as we now have more than one type of tooltip. If we want to add any more changes to this PR to make the tooltips feel even more responsive (or if we want to update the design) let me know.