### PR TITLE
Fix item selection on messages page

### DIFF
--- a/frontend/src/components/views/MessagesView.tsx
+++ b/frontend/src/components/views/MessagesView.tsx
@@ -46,7 +46,7 @@ const MessagesView = () => {
     const unreadTimer = useRef<NodeJS.Timeout>()
 
     const threads = useMemo(() => data?.pages.flat().filter((thread) => thread != null) ?? [], [data])
-    useItemSelectionController(threads, (itemId: string) => navigate(`/messages/${itemId}`))
+    useItemSelectionController(threads, (itemId: string) => navigate(`/messages/${params.mailbox}/${itemId}`))
 
     const { expandedThread, expandedIndex } = useMemo(() => {
         if (threads.length > 0) {


### PR DESCRIPTION
Previously it would route you to a broken page and not actually select the next thing in the list if you pressed an arrow key. My bad.