### PR TITLE
Change source ID of email to task back to GT

### DIFF
--- a/backend/api/task_create_from_thread.go
+++ b/backend/api/task_create_from_thread.go
@@ -76,7 +76,7 @@ func createTaskFromEmailThread(
 			UserID:          userID,
 			IDExternal:      primitive.NewObjectID().Hex(),
 			IDTaskSection:   taskSection,
-			SourceID:        external.TASK_SOURCE_ID_GMAIL,
+			SourceID:        external.TASK_SOURCE_ID_GT_TASK,
 			Title:           params.Title,
 			Body:            params.Body,
 			SourceAccountID: accountID,

--- a/backend/api/task_create_from_thread_test.go
+++ b/backend/api/task_create_from_thread_test.go
@@ -3,10 +3,11 @@ package api
 import (
 	"bytes"
 	"context"
-	"github.com/GeneralTask/task-manager/backend/constants"
-	"go.mongodb.org/mongo-driver/bson"
 	"net/http"
 	"testing"
+
+	"github.com/GeneralTask/task-manager/backend/constants"
+	"go.mongodb.org/mongo-driver/bson"
 
 	"github.com/GeneralTask/task-manager/backend/database"
 	"github.com/GeneralTask/task-manager/backend/external"
@@ -76,7 +77,7 @@ func TestCreateTaskFromThread(t *testing.T) {
 		var task database.Item
 		err = taskCollection.FindOne(dbCtx, bson.M{"title": "sample title", "user_id": userID}).Decode(&task)
 		assert.True(t, task.IsTask)
-		assert.Equal(t, external.TASK_SOURCE_ID_GMAIL, task.SourceID)
+		assert.Equal(t, external.TASK_SOURCE_ID_GT_TASK, task.SourceID)
 		assert.Equal(t, threadID, *task.LinkedMessage.ThreadID)
 		assert.Equal(t, "deeplink.com/wut", task.Deeplink)
 		assert.Nil(t, task.LinkedMessage.EmailID)
@@ -91,7 +92,7 @@ func TestCreateTaskFromThread(t *testing.T) {
 		var task database.Item
 		err = taskCollection.FindOne(dbCtx, bson.M{"title": "sample title 2", "user_id": userID}).Decode(&task)
 		assert.True(t, task.IsTask)
-		assert.Equal(t, external.TASK_SOURCE_ID_GMAIL, task.SourceID)
+		assert.Equal(t, external.TASK_SOURCE_ID_GT_TASK, task.SourceID)
 		assert.Equal(t, threadID, *task.LinkedMessage.ThreadID)
 		assert.Equal(t, firstEmailID, *task.LinkedMessage.EmailID)
 	})

--- a/backend/api/task_details_test.go
+++ b/backend/api/task_details_test.go
@@ -4,13 +4,14 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/GeneralTask/task-manager/backend/constants"
-	"github.com/GeneralTask/task-manager/backend/testutils"
-	"go.mongodb.org/mongo-driver/bson"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/GeneralTask/task-manager/backend/constants"
+	"github.com/GeneralTask/task-manager/backend/testutils"
+	"go.mongodb.org/mongo-driver/bson"
 
 	"github.com/GeneralTask/task-manager/backend/database"
 	"github.com/GeneralTask/task-manager/backend/external"
@@ -187,7 +188,7 @@ func TestTaskDetail(t *testing.T) {
 		body := ServeRequest(t, authToken, "GET", fmt.Sprintf("/tasks/detail/%s/", task.ID.Hex()),
 			nil, http.StatusOK)
 		assert.Equal(t,
-			fmt.Sprintf(`{"id":"%s","id_ordering":0,"source":{"name":"Gmail","logo":"/images/gmail.svg","logo_v2":"gmail","is_completable":true,"is_replyable":true},"deeplink":"","title":"sample title","body":"sample body","sender":"","due_date":"","time_allocated":0,"sent_at":"1970-01-01T00:00:00Z","is_done":false,"linked_email_thread":{"linked_thread_id":"%s","linked_email_id":"%s","email_thread":{"id":"%s","deeplink":"","is_task":false,"is_archived":false,"source":{"account_id":"","name":"Gmail","logo":"/images/gmail.svg","logo_v2":"gmail","is_replyable":true},"emails":[{"message_id":"%s","subject":"test subject 1","body":"test body 1","sent_at":"2019-04-20T00:00:00Z","is_unread":true,"sender":{"name":"test","email":"test@generaltask.com","reply_to":"test-reply@generaltask.com"},"recipients":{"to":[{"name":"p1","email":"p1@gmail.com"}],"cc":[{"name":"p2","email":"p2@gmail.com"}],"bcc":[{"name":"p3","email":"p3@gmail.com"}]},"num_attachments":0},{"message_id":"000000000000000000000000","subject":"test subject 2","body":"test body 2","sent_at":"2018-04-20T00:00:00Z","is_unread":true,"sender":{"name":"test","email":"test@generaltask.com","reply_to":""},"recipients":{"to":[],"cc":[],"bcc":[]},"num_attachments":0}]}}}`,
+			fmt.Sprintf(`{"id":"%s","id_ordering":0,"source":{"name":"General Task","logo":"/images/generaltask.svg","logo_v2":"generaltask","is_completable":true,"is_replyable":false},"deeplink":"","title":"sample title","body":"sample body","sender":"","due_date":"","time_allocated":0,"sent_at":"1970-01-01T00:00:00Z","is_done":false,"linked_email_thread":{"linked_thread_id":"%s","linked_email_id":"%s","email_thread":{"id":"%s","deeplink":"","is_task":false,"is_archived":false,"source":{"account_id":"","name":"Gmail","logo":"/images/gmail.svg","logo_v2":"gmail","is_replyable":true},"emails":[{"message_id":"%s","subject":"test subject 1","body":"test body 1","sent_at":"2019-04-20T00:00:00Z","is_unread":true,"sender":{"name":"test","email":"test@generaltask.com","reply_to":"test-reply@generaltask.com"},"recipients":{"to":[{"name":"p1","email":"p1@gmail.com"}],"cc":[{"name":"p2","email":"p2@gmail.com"}],"bcc":[{"name":"p3","email":"p3@gmail.com"}]},"num_attachments":0},{"message_id":"000000000000000000000000","subject":"test subject 2","body":"test body 2","sent_at":"2018-04-20T00:00:00Z","is_unread":true,"sender":{"name":"test","email":"test@generaltask.com","reply_to":""},"recipients":{"to":[],"cc":[],"bcc":[]},"num_attachments":0}]}}}`,
 				task.ID.Hex(), threadID.Hex(), firstEmailID.Hex(), threadID.Hex(), firstEmailID.Hex()),
 			string(body))
 	})


### PR DESCRIPTION
This is done to prevent auto-complete. This change will be reverted eventually, but this will be tracked in a separate Linear task.