### PR TITLE
Add 404 check on gmail history fetching

### DIFF
--- a/backend/external/gmail.go
+++ b/backend/external/gmail.go
@@ -94,6 +94,7 @@ func (gmailSource GmailSource) GetEmails(userID primitive.ObjectID, accountID st
 		historiesRequiringUpdate, recentHistoryID, err = getAllRecentGmailHistory(gmailService, latestHistoryID)
 		if err != nil {
 			// retry request with full refresh in history fetching fails
+			// this will happen if the history is too old and too many threads will be returned
 			if strings.Contains(err.Error(), "Error 404") {
 				log.Error().Err(err).Msg("failed to fetch history")
 				gmailSource.GetEmails(userID, accountID, latestHistoryID, result, true)


### PR DESCRIPTION
As per title. There was an issue where if the history was too old, the fetching would fail. This introduces logic to try a full refresh if the history 404s.