### PR TITLE
Add missing error handling for Slack create task

### DIFF
--- a/backend/api/task_create.go
+++ b/backend/api/task_create.go
@@ -83,6 +83,10 @@ func (api *API) SlackTaskCreate(c *gin.Context) {
 
 	externalID := external.GenerateSlackUserID(slackParams.Team.ID, slackParams.User.ID)
 	externalToken, err := database.GetExternalToken(db, externalID, sourceID)
+	if err != nil {
+		Handle500(c)
+		return
+	}
 	userID := externalToken.UserID
 
 	IDTaskSection := constants.IDTaskSectionDefault


### PR DESCRIPTION
There was a single missing error check in the Slack task creation