### PR TITLE
Event request datetime

### DIFF
--- a/frontend/src/utils/time.ts
+++ b/frontend/src/utils/time.ts
@@ -11,12 +11,9 @@ export function getMonthsAroundDate(date: DateTime, numMonths = 1): DateRange[] 
     const startOfFirstMonth = date.startOf('month').minus({ months: numMonths })
     const endOfFirstMonth = date.endOf('month').minus({ months: numMonths })
 
-    return [...Array(numMonths * 2 + 1).keys()].map((i: number): DateRange => {
-        return {
+    return [...Array(numMonths * 2 + 1).keys()].map((i: number): DateRange => ({
             start: startOfFirstMonth.plus({ months: i }).startOf('month'),
             end: endOfFirstMonth.plus({ months: i }).endOf('month'),
-        }
-    })
-
+        }))
 }
 


### PR DESCRIPTION
Fix bug so that the event request includes the last day of the month
(ex. start: 07/01, end: 07/30 --> start: 07/01, end: 07/31)

https://user-images.githubusercontent.com/54857128/177420778-469f87af-6ceb-4ea9-955a-aa864aba9ffc.mov

 