### PR TITLE
hardcode deeplink label for tasks created from emails

### DIFF
--- a/frontend/src/components/details/TaskDetails.tsx
+++ b/frontend/src/components/details/TaskDetails.tsx
@@ -192,6 +192,7 @@ const TaskDetails = ({ task }: TaskDetailsProps) => {
 
     // Temporary hack to check source of linked task. All tasks currently have a hardcoded sourceID to GT (see PR #1104)
     const icon = task.linked_email_thread ? logos.gmail : logos[task.source.logo_v2]
+    const deeplinkLabel = task.linked_email_thread ? 'Gmail' : task.source.name
 
     const status = task.external_status ? task.external_status.state : ''
 
@@ -215,7 +216,7 @@ const TaskDetails = ({ task }: TaskDetailsProps) => {
                                 <NoStyleAnchor href={task.deeplink} target="_blank" rel="noreferrer">
                                     <RoundedGeneralButton
                                         textStyle="dark"
-                                        value={task.source.name}
+                                        value={deeplinkLabel}
                                         hasBorder
                                         iconSource="external_link"
                                     />


### PR DESCRIPTION
quick fix.
<img width="939" alt="Screen Shot 2022-07-06 at 11 22 12 AM" src="https://user-images.githubusercontent.com/31417618/177617338-1240103a-8412-4c26-ad3d-88c895b177c3.png">


Before:

<img width="940" alt="Screen Shot 2022-07-06 at 11 22 32 AM" src="https://user-images.githubusercontent.com/31417618/177617399-3272c9b8-a71c-4a00-885b-5f7ad9cd7422.png">

