### PR TITLE
Add Slack modal method

### DIFF
--- a/backend/external/slack_saved.go
+++ b/backend/external/slack_saved.go
@@ -212,3 +212,62 @@ func getSlackUsername(client *slack.Client, userID string, result chan<- string)
 	result <- userProfile.Profile.DisplayName
 	return
 }
+
+func GetSlackModal(triggerID string) []byte {
+	return []byte(`{
+		"trigger_id": "` + triggerID + `",
+		"view": {
+			"title": {
+				"type": "plain_text",
+				"text": "Create a new task",
+				"emoji": true
+			},
+			"submit": {
+				"type": "plain_text",
+				"text": "Submit",
+				"emoji": true
+			},
+			"type": "modal",
+			"close": {
+				"type": "plain_text",
+				"text": "Cancel",
+				"emoji": true
+			},
+			"blocks": [
+				{
+					"block_id": "task_title",
+					"type": "input",
+					"optional": true,
+					"label": {
+						"type": "plain_text",
+						"text": "Enter a task title"
+					},
+					"element": {
+						"type": "plain_text_input",
+						"placeholder": {
+							"type": "plain_text",
+							"text": "Optional task title"
+						}
+					}
+				},
+				{
+					"block_id": "task_details",
+					"type": "input",
+					"optional": true,
+					"label": {
+						"type": "plain_text",
+						"text": "Enter task details"
+					},
+					"element": {
+						"type": "plain_text_input",
+						"multiline": true,
+						"placeholder": {
+							"type": "plain_text",
+							"text": "Optional task title"
+						}
+					}
+				}
+			]
+		}
+	}`)
+}


### PR DESCRIPTION
We must do the modal in this form. The Slack client library doesn't support optional fields in modals, so we need the raw JSON to make the request. Will follow up with a (dependent) PR that uses this method to generate the request, and then handle the modal interactions.