### PR TITLE
Increase timeout for gmail requests

### DIFF
--- a/backend/external/gmail.go
+++ b/backend/external/gmail.go
@@ -364,7 +364,7 @@ func getThreadFromGmail(gmailService *gmail.Service, threadID string, result cha
 		RandomizationFactor: 2.0,
 		Multiplier:          backoff.DefaultMultiplier,
 		MaxInterval:         backoff.DefaultMaxInterval,
-		MaxElapsedTime:      10 * time.Second,
+		MaxElapsedTime:      30 * time.Second,
 		Stop:                backoff.Stop,
 		Clock:               backoff.SystemClock,
 	}


### PR DESCRIPTION
Gmail thread requests would previously timeout at 10s. Some of our requests take ~9s or longer, so we may be butting up against this limit. Bumping this up to allow for longer loading.