### PR TITLE
Stop week view in collapsed day mode calendar

### DIFF
--- a/frontend/src/components/calendar/CalendarEvents.tsx
+++ b/frontend/src/components/calendar/CalendarEvents.tsx
@@ -132,7 +132,7 @@ const CalendarEvents = ({ date, numDays, accountId }: CalendarEventsProps) => {
             allGroups.push(findCollisionGroups(eventList ?? []))
         }
         return allGroups
-    }, [date, eventPreviousMonth, eventsCurrentMonth, eventsNextMonth])
+    }, [date, eventPreviousMonth, eventsCurrentMonth, eventsNextMonth, numDays])
 
     useInterval(
         () => {

--- a/frontend/src/components/views/CalendarView.tsx
+++ b/frontend/src/components/views/CalendarView.tsx
@@ -1,6 +1,6 @@
 import CalendarHeader, { CaretButton } from '../calendar/CalendarHeader'
 import { Colors, Spacing } from '../../styles'
-import React, { useMemo, useState } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 
 import { CalendarContainer } from '../calendar/CalendarEvents-styles'
 import CalendarEvents from '../calendar/CalendarEvents'
@@ -43,6 +43,10 @@ const CalendarView = ({ isExpanded }: CalendarViewProps) => {
         dispatch(setExpandedCalendar(false))
         setIsCalendarCollapsed(true)
     }
+
+    useEffect(() => {
+        dispatch(setExpandedCalendar(false))
+    }, [])
 
     useInterval(
         () => {


### PR DESCRIPTION
Make sure the calendar always shows a single day on the page navigation. 
Before: 
![before](https://user-images.githubusercontent.com/54857128/178058324-2f2232bd-7e2e-41b4-84f4-f60b90de9829.png)
After:
https://user-images.githubusercontent.com/54857128/178058355-a2108867-f4b6-41d9-ad72-7880992cc102.mov