### PR TITLE
Add min-width to overview page

### DIFF
--- a/frontend/src/components/views/OverviewPageView.tsx
+++ b/frontend/src/components/views/OverviewPageView.tsx
@@ -25,14 +25,6 @@ const ActionsContainer = styled.div`
     display: flex;
     justify-content: flex-end;
 `
-const DetailsViewContainer = styled.div`
-    background-color: ${Colors.white};
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    padding-top: 50vh;
-    flex-basis: 400px;
-`
 
 const OverviewView = () => {
     const { data: views, isLoading } = useGetOverviewViews()


### PR DESCRIPTION
Stop from text/tasks to overlap in the overview page 
Before: 
<img width="371" alt="Screen Shot 2022-07-11 at 6 20 41 PM" src="https://user-images.githubusercontent.com/54857128/178554582-59dc5282-ed2d-41b0-a46c-343de90fec80.png">

After: 
<img width="371" alt="Screen Shot 2022-07-12 at 12 22 23 PM" src="https://user-images.githubusercontent.com/54857128/178554838-bfe14469-521a-4a88-a316-3c2de5f34de0.png">


