### PR TITLE
Fix line separator flashing on task section

### DIFF
--- a/frontend/src/components/details/TaskDetails.tsx
+++ b/frontend/src/components/details/TaskDetails.tsx
@@ -27,7 +27,6 @@ const DetailsViewContainer = styled.div`
     flex-direction: column;
     background-color: ${Colors.gray._50};
     min-width: 300px;
-    border-left: 1px solid ${Colors.gray._300};
     padding: ${Spacing.padding._40} ${Spacing.padding._16} ${Spacing.padding._16};
 `
 const DetailsTopContainer = styled.div`

--- a/frontend/src/components/views/TaskSectionView.tsx
+++ b/frontend/src/components/views/TaskSectionView.tsx
@@ -20,6 +20,7 @@ import ReorderDropContainer from '../atoms/ReorderDropContainer'
 const BannerAndSectionContainer = styled.div`
     display: flex;
     flex-direction: column;
+    border-right: 1px solid ${Colors.gray._300};
     margin-right: auto;
     flex-shrink: 0;
     position: relative;


### PR DESCRIPTION
When a user switches between task sections, the divider separating the list and details view should not flash. 

Before: 
https://user-images.githubusercontent.com/54857128/178565871-5b8a7ee0-1a49-47cf-b8bc-5733730332ac.mov
After: 
https://user-images.githubusercontent.com/54857128/178565864-dd395ee1-384a-4871-842a-4839468b68d8.mov
