### PR TITLE
Update IsServiceLinked for GT task service

### DIFF
--- a/backend/api/overview.go
+++ b/backend/api/overview.go
@@ -172,6 +172,9 @@ func (api *API) GetTaskSectionOverviewResult(db *mongo.Database, ctx context.Con
 }
 
 func (api *API) IsServiceLinked(db *mongo.Database, ctx context.Context, userID primitive.ObjectID, serviceID string) (bool, error) {
+	if serviceID == external.TASK_SERVICE_ID_GT {
+		return true, nil
+	}
 	externalAPITokenCollection := database.GetExternalTokenCollection(db)
 	dbCtx, cancel := context.WithTimeout(ctx, constants.DatabaseTimeout)
 	defer cancel()

--- a/backend/api/overview_test.go
+++ b/backend/api/overview_test.go
@@ -524,6 +524,11 @@ func TestIsServiceLinked(t *testing.T) {
 		assert.NoError(t, err)
 		assert.False(t, result)
 	})
+	t.Run("TaskServiceIsTrue", func(t *testing.T) {
+		result, err := api.IsServiceLinked(db, parentCtx, userID, external.TASK_SERVICE_ID_GT)
+		assert.NoError(t, err)
+		assert.True(t, result)
+	})
 }
 
 func TestOverviewViewDelete(t *testing.T) {


### PR DESCRIPTION
Task section views are considered linked, so we return true if the type is `TASK_SERVICE_ID_GT`