### PR TITLE
tasks/get before tasks/fetch when manually refreshing

### DIFF
--- a/frontend/src/components/views/TaskSectionView.tsx
+++ b/frontend/src/components/views/TaskSectionView.tsx
@@ -54,12 +54,22 @@ const TaskSectionView = () => {
     const bannerTaskSectionRef = useRef<HTMLDivElement | null>(null)
     const sectionViewRef = useRef<HTMLDivElement>(null)
 
-    const { data: taskSections, isLoading: isLoadingTasks, isFetching: isFetchingTasks } = useGetTasks()
+    const {
+        data: taskSections,
+        isLoading: isLoadingTasks,
+        isFetching: isFetchingTasks,
+        refetch: getTasks,
+    } = useGetTasks()
     const { mutate: reorderTask } = useReorderTask()
     const { refetch: fetchExternal, isFetching: isFetchingExternal } = useFetchExternalTasks()
 
     const navigate = useNavigate()
     const params = useParams()
+
+    const refresh = () => {
+        getTasks()
+        fetchExternal()
+    }
 
     const { section, task } = useMemo(() => {
         const section = taskSections?.find(({ id }) => id === params.section)
@@ -113,7 +123,7 @@ const TaskSectionView = () => {
                                 <SectionHeader
                                     sectionName={section.name}
                                     allowRefresh={true}
-                                    refetch={fetchExternal}
+                                    refetch={refresh}
                                     isRefreshing={isFetchingExternal || isFetchingTasks}
                                     taskSectionId={section.id}
                                 />


### PR DESCRIPTION
In order to further improve john's refresh times, we may need to look into pagination for the tasks endpoint. Loading 1000 tasks at once is a sizeable amount of data 🙃 