### PR TITLE
Update supported views endpoint to now return Github views

### DIFF
--- a/backend/api/overview.go
+++ b/backend/api/overview.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"errors"
+	"sort"
 	"time"
 
 	"github.com/GeneralTask/task-manager/backend/constants"
@@ -641,6 +642,9 @@ func (api *API) getSupportedGithubViews(db *mongo.Database, userID primitive.Obj
 	for _, supportedViewItem := range repositoryIDToSupportedViewItems {
 		supportedViewItems = append(supportedViewItems, supportedViewItem)
 	}
+	sort.Slice(supportedViewItems, func(i, j int) bool {
+		return supportedViewItems[i].Name < supportedViewItems[j].Name
+	})
 	return supportedViewItems, nil
 }
 


### PR DESCRIPTION
Also fix the `invalid view type` bug that didn't account for the slack type