### PR TITLE
Fix null view_items for linear/slack task results

### DIFF
--- a/backend/api/overview.go
+++ b/backend/api/overview.go
@@ -297,7 +297,7 @@ func (api *API) GetLinearOverviewResult(db *mongo.Database, ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
-	var taskResults []*TaskResult
+	taskResults := []*TaskResult{}
 	for _, task := range *linearTasks {
 		taskResults = append(taskResults, api.taskBaseToTaskResult(&task, userID))
 	}
@@ -342,7 +342,7 @@ func (api *API) GetSlackOverviewResult(db *mongo.Database, ctx context.Context, 
 	if err != nil {
 		return nil, err
 	}
-	var taskResults []*TaskResult
+	taskResults := []*TaskResult{}
 	for _, task := range *slackTasks {
 		taskResults = append(taskResults, api.taskBaseToTaskResult(&task, userID))
 	}


### PR DESCRIPTION
Wasn't able to fully confirm this works, but it makes sense based off of this:
https://github.com/GeneralTask/task-manager/pull/1376/files

closes BACK-123 (again)