### PR TITLE
Add fields to PullRequestUpdateable to avoid stale data

### DIFF
--- a/backend/database/models.go
+++ b/backend/database/models.go
@@ -179,10 +179,12 @@ type PullRequest struct {
 }
 
 type PullRequestChangeableFields struct {
-	Title         string             `bson:"title,omitempty"`
-	Body          string             `bson:"body,omitempty"`
-	IsCompleted   *bool              `bson:"is_completed,omitempty"`
-	LastUpdatedAt primitive.DateTime `bson:"last_updated_at"`
+	Title          string             `bson:"title,omitempty"`
+	Body           string             `bson:"body,omitempty"`
+	RequiredAction string             `bson:"required_action"`
+	CommentCount   int                `bson:"comment_count"`
+	LastUpdatedAt  primitive.DateTime `bson:"last_updated_at"`
+	IsCompleted    *bool              `bson:"is_completed,omitempty"`
 }
 
 type CalendarEvent struct {

--- a/backend/external/github_pr.go
+++ b/backend/external/github_pr.go
@@ -197,10 +197,12 @@ func (gitPR GithubPRSource) GetPullRequests(userID primitive.ObjectID, accountID
 			pullRequest.SourceID,
 			pullRequest,
 			database.PullRequestChangeableFields{
-				Title:         pullRequest.Title,
-				Body:          pullRequest.TaskBase.Body,
-				IsCompleted:   &isCompleted,
-				LastUpdatedAt: pullRequest.PullRequest.LastUpdatedAt,
+				Title:          pullRequest.Title,
+				Body:           pullRequest.TaskBase.Body,
+				IsCompleted:    &isCompleted,
+				LastUpdatedAt:  pullRequest.PullRequest.LastUpdatedAt,
+				CommentCount:   pullRequest.CommentCount,
+				RequiredAction: pullRequest.RequiredAction,
 			},
 			nil,
 			false)


### PR DESCRIPTION
IIUC it seems like most PR fields weren't updating at all after the first time we saved them in the DB