### PR TITLE
Only load the most recent 100 completed tasks

### DIFF
--- a/backend/constants/database.go
+++ b/backend/constants/database.go
@@ -1,0 +1,3 @@
+package constants
+
+var MAX_COMPLETED_TASKS = 100

--- a/backend/database/helpers.go
+++ b/backend/database/helpers.go
@@ -380,6 +380,7 @@ func GetCompletedTasks(db *mongo.Database, userID primitive.ObjectID) (*[]Item, 
 
 	findOptions := options.Find()
 	findOptions.SetSort(bson.D{{Key: "completed_at", Value: -1}, {Key: "_id", Value: -1}})
+	findOptions.SetLimit(int64(constants.MAX_COMPLETED_TASKS))
 
 	dbCtx, cancel := context.WithTimeout(parentCtx, constants.DatabaseTimeout)
 	defer cancel()


### PR DESCRIPTION
We can later paginate this if we want, but this will quickly reduce the pain for anyone with a ton of completed tasks