### PR TITLE
Set a max-width on event banner so it overflows earlier

### DIFF
--- a/frontend/src/components/molecules/EventBanners.tsx
+++ b/frontend/src/components/molecules/EventBanners.tsx
@@ -27,7 +27,7 @@ const BannerView = styled.div<{ center: boolean }>`
     padding-left: 12px;
     padding-right: 6px;
     margin-bottom: 8px;
-    width: 500px;
+    max-width: 450px;
     height: 50px;
     background-color: ${Colors.background.white};
     opacity: 0.97;
@@ -72,7 +72,7 @@ interface EventBannerProps {
 }
 const EventBanner = ({ event }: EventBannerProps) => {
     const timeUntilEvent = Math.ceil((new Date(event.datetime_start).getTime() - new Date().getTime()) / 1000 / 60)
-    const timeUntilEventMessage = timeUntilEvent > 0 ? `in ${timeUntilEvent} minutes.` : 'is now.'
+    const timeUntilEventMessage = timeUntilEvent > 0 ? `is in ${timeUntilEvent} minutes.` : 'is now.'
     const eventTitle = event.title.length > 0 ? event.title : NO_EVENT_TITLE
     return (
         <BannerView key={event.id} center={event.conference_call == null}>


### PR DESCRIPTION
This isn't an optimal solution, but we need to go back and re-do the event banner anyway so this is more of a bandaid solution.  Event banner is OLD code and it will take a little while to refactor it.

![image](https://user-images.githubusercontent.com/31417618/180858253-5db3ba32-6336-494d-b112-07385bd0755c.png)
