### PR TITLE
Fix bug related to button widths

### DIFF
--- a/frontend/src/components/atoms/buttons/GTButton.tsx
+++ b/frontend/src/components/atoms/buttons/GTButton.tsx
@@ -43,14 +43,19 @@ const SmallButtonStyle = css`
     ${Typography.bodySmall}
 `
 
-const Button = styled(NoStyleButton)<{ styleType: TButtonStyle; wrapText: boolean; size: TButtonSize }>`
+const Button = styled(NoStyleButton)<{
+    styleType: TButtonStyle
+    wrapText: boolean
+    fitContent: boolean
+    size: TButtonSize
+}>`
     display: flex;
     justify-content: center;
     align-items: center;
     border-radius: ${Border.radius.small};
     text-align: center;
     height: 100%;
-    width: 100%;
+    width: ${(props) => (props.fitContent ? 'fit-content' : '100%')};
     box-shadow: ${Shadows.button.default};
     white-space: ${(props) => (props.wrapText ? 'normal' : 'nowrap')};
     overflow: hidden;
@@ -69,19 +74,21 @@ interface GTButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
     styleType?: TButtonStyle
     size?: TButtonSize
     wrapText?: boolean
+    fitContent?: boolean
     iconSource?: TIconImage
 }
 const GTButton = ({
     styleType = 'primary',
     size = 'large',
     wrapText = false,
+    fitContent = true,
     iconSource,
     value,
     ...rest
 }: GTButtonProps) => {
     const iconSize = size === 'small' ? 'xSmall' : 'small'
     return (
-        <Button styleType={styleType} size={size} wrapText={wrapText} {...rest}>
+        <Button styleType={styleType} size={size} wrapText={wrapText} fitContent={fitContent} {...rest}>
             {iconSource && <Icon size={iconSize} source={icons[iconSource]} />}
             {value}
         </Button>

--- a/frontend/src/components/molecules/FeedbackButton.tsx
+++ b/frontend/src/components/molecules/FeedbackButton.tsx
@@ -13,7 +13,7 @@ const FeedbackButton = () => {
     }
     return (
         <>
-            <GTButton value="Share feedback" styleType="secondary" onClick={openModal} />
+            <GTButton value="Share feedback" styleType="secondary" fitContent={false} onClick={openModal} />
             <ModalView>
                 <FeedbackView />
             </ModalView>

--- a/frontend/src/components/overview/AuthBanner.tsx
+++ b/frontend/src/components/overview/AuthBanner.tsx
@@ -26,9 +26,6 @@ const IconContainer = styled.div`
     align-items: center;
     gap: ${Spacing.padding._12};
 `
-const ConnectButton = styled(GTButton)`
-    height: 28px;
-`
 const Title = styled.span`
     ${Typography.bodySmall};
 `
@@ -58,7 +55,7 @@ const AuthBanner = ({ authorizationUrl, name, logo, hasBorder }: AuthBannerProps
                 <Icon size="small" source={logos[logo]} />
                 <Title>{`Connect ${name} to General Task`}</Title>
             </IconContainer>
-            <ConnectButton
+            <GTButton
                 value="Connect"
                 color={Colors.gtColor.primary}
                 onClick={() => openPopupWindow(authorizationUrl, onWindowClose)}

--- a/frontend/src/components/views/NavigationView.tsx
+++ b/frontend/src/components/views/NavigationView.tsx
@@ -45,7 +45,12 @@ const NavigationView = () => {
             </OverflowContainer>
             <GapView>
                 <FeedbackButton />
-                <GTButton value="Settings" styleType="secondary" onClick={() => navigate('/settings')} />
+                <GTButton
+                    value="Settings"
+                    styleType="secondary"
+                    fitContent={false}
+                    onClick={() => navigate('/settings')}
+                />
             </GapView>
         </NavigationViewContainer>
     )

--- a/frontend/src/components/views/SettingsView.tsx
+++ b/frontend/src/components/views/SettingsView.tsx
@@ -111,6 +111,7 @@ const SettingsView = () => {
                                         e.stopPropagation()
                                         setShowLinkedAccountsDropdown(!showLinkAccountsDropdown)
                                     }}
+                                    fitContent={false}
                                     value="Add new Account"
                                     styleType="primary"
                                 />


### PR DESCRIPTION
Allow GTbutton to either be width of content, or width of container.

A default `width: 100%` lead to bugs like the following:
<img width="527" alt="Screen Shot 2022-08-06 at 2 44 01 PM" src="https://user-images.githubusercontent.com/9156543/183266992-4765a60a-5f03-44f4-a2e1-0018c7c0b96e.png">

