### PR TITLE
Empty state views

### DIFF
--- a/frontend/src/components/details/EmptyDetails.tsx
+++ b/frontend/src/components/details/EmptyDetails.tsx
@@ -1,0 +1,35 @@
+import React from 'react'
+import styled from 'styled-components'
+import { Colors, Spacing, Typography } from '../../styles'
+import { Icon } from '../atoms/Icon'
+
+const DetailsViewContainer = styled.div`
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    background-color: ${Colors.background.light};
+    min-width: 300px;
+    justify-content: center;
+    align-items: center;
+    gap: ${Spacing.margin._16};
+`
+const Text = styled.span`
+    color: ${Colors.text.light};
+    ${Typography.title};
+`
+
+interface EmptyDetailsProps {
+    iconSource: string
+    text: string
+}
+
+const EmptyDetails = ({ iconSource, text }: EmptyDetailsProps) => {
+    return (
+        <DetailsViewContainer>
+            <Icon size="xLarge" source={iconSource} />
+            <Text>{text}</Text>
+        </DetailsViewContainer>
+    )
+}
+
+export default EmptyDetails

--- a/frontend/src/components/views/OverviewPageView.tsx
+++ b/frontend/src/components/views/OverviewPageView.tsx
@@ -11,6 +11,8 @@ import { TPullRequest, TTask } from '../../utils/types'
 import Spinner from '../atoms/Spinner'
 import PullRequestDetails from '../details/PullRequestDetails'
 import { SectionHeader } from '../molecules/Header'
+import EmptyDetails from '../details/EmptyDetails'
+import { icons } from '../../styles/images'
 
 const OverviewPageContainer = styled.div`
     display: flex;
@@ -36,8 +38,8 @@ const OverviewView = () => {
     }
 
     const detailsView = useMemo(() => {
-        if (!views || !overviewItem) {
-            return null
+        if (!views?.length) {
+            return <EmptyDetails iconSource={icons.list} text="You have no views" />
         }
         for (const view of views) {
             for (const item of view.view_items) {
@@ -58,7 +60,7 @@ const OverviewView = () => {
         if (!isLoading && (!overviewItem || !detailsView)) {
             selectFirstItem()
         }
-    }, [])
+    }, [isLoading, overviewItem])
 
     if (isLoading) {
         return <Spinner />

--- a/frontend/src/components/views/PullRequestsView.tsx
+++ b/frontend/src/components/views/PullRequestsView.tsx
@@ -11,6 +11,8 @@ import { useNavigate, useParams } from 'react-router-dom'
 import useItemSelectionController from '../../hooks/useItemSelectionController'
 import { Colors } from '../../styles'
 import styled from 'styled-components'
+import EmptyDetails from '../details/EmptyDetails'
+import { logos } from '../../styles/images'
 
 const PullRequestsContainer = styled.div`
     display: flex;
@@ -79,7 +81,11 @@ const PullRequestsView = () => {
                     </PullRequestViewContainer>
                 </ScrollableListTemplate>
             </PullRequestsContainer>
-            {expandedPullRequest && <PullRequestDetails pullRequest={expandedPullRequest} />}
+            {expandedPullRequest ? (
+                <PullRequestDetails pullRequest={expandedPullRequest} />
+            ) : (
+                <EmptyDetails iconSource={logos.github_gray} text="You have no pull requests" />
+            )}
         </>
     )
 }

--- a/frontend/src/components/views/TaskSectionView.tsx
+++ b/frontend/src/components/views/TaskSectionView.tsx
@@ -16,6 +16,8 @@ import ScheduleGapFiller from '../atoms/scheduleGapFiller/ScheduleGapFiller'
 import { DEFAULT_VIEW_WIDTH } from '../../styles/dimensions'
 import { DropItem, DropType } from '../../utils/types'
 import ReorderDropContainer from '../atoms/ReorderDropContainer'
+import EmptyDetails from '../details/EmptyDetails'
+import { icons } from '../../styles/images'
 
 const BannerAndSectionContainer = styled.div`
     display: flex;
@@ -114,7 +116,7 @@ const TaskSectionView = () => {
                 navigate(`/tasks/${section.id}/${section.tasks[0].id}`)
             }
         }
-    }, [taskSections, params.section])
+    }, [taskSections, params.section, params.task])
 
     useItemSelectionController(section?.tasks ?? [], selectTask)
 
@@ -170,7 +172,11 @@ const TaskSectionView = () => {
                     </TaskSectionViewContainer>
                 </ScrollViewMimic>
             </BannerAndSectionContainer>
-            {task && section && <TaskDetails task={task} link={`/tasks/${params.section}/${task.id}`} />}
+            {task && section ? (
+                <TaskDetails task={task} link={`/tasks/${params.section}/${task.id}`} />
+            ) : (
+                <EmptyDetails iconSource={icons.check_gray} text="You have no tasks" />
+            )}
             <ScheduleGapFiller />
         </>
     )

--- a/frontend/src/styles/dimensions.ts
+++ b/frontend/src/styles/dimensions.ts
@@ -4,6 +4,7 @@ export const iconSize = {
     small: '20px',
     medium: '30px',
     large: '40px',
+    xLarge: '50px',
 }
 
 export type TIconSize = keyof typeof iconSize


### PR DESCRIPTION
Adds empty state views for overview views, pull requests, and task sections.

One note: the gray for the icons doesn't always match the text gray. This will be fixed eventually when we have the fontawesome icons implemented and we can choose arbitrary colors.

Example:
![image](https://user-images.githubusercontent.com/31417618/184427404-72be8375-7ef5-48e8-88dc-112a33748dbf.png)
