### PR TITLE
Prefetch supported views on overview page

### DIFF
--- a/frontend/src/components/views/OverviewPageView.tsx
+++ b/frontend/src/components/views/OverviewPageView.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import styled from 'styled-components'
-import { useGetOverviewViews } from '../../services/api/overview.hooks'
+import { useGetOverviewViews, useGetSupportedViews } from '../../services/api/overview.hooks'
 import { Colors, Spacing } from '../../styles'
 import TaskDetails from '../details/TaskDetails'
 import EditViewsButtons from '../overview/EditViewsButtons'
@@ -29,6 +29,9 @@ const OverviewView = () => {
     const { data: views, refetch, isLoading, isFetching } = useGetOverviewViews()
     const { overviewItem } = useParams()
     const navigate = useNavigate()
+
+    // Prefetch supported views
+    useGetSupportedViews()
 
     const selectFirstItem = () => {
         const firstNonEmptyView = views?.find((view) => view.view_items.length > 0)


### PR DESCRIPTION
This PR omits the "prefetch settings supported integrations" because that's already what we do.  After testing, it was determined that it could have been an old branch or a separate bug that caused that behavior.