### PR TITLE
Fix misc popup big fixes

### DIFF
--- a/frontend/src/components/calendar/EventBody.tsx
+++ b/frontend/src/components/calendar/EventBody.tsx
@@ -1,5 +1,5 @@
 import { DateTime } from 'luxon'
-import React, { useRef, MouseEvent, useEffect, useState } from 'react'
+import React, { useRef, MouseEvent, useLayoutEffect, useEffect, useState } from 'react'
 import { TEvent } from '../../utils/types'
 import {
     CELL_HEIGHT_VALUE,
@@ -49,7 +49,12 @@ function EventBody(props: EventBodyProps): JSX.Element {
     const isLongEvent = timeDurationMinutes >= LONG_EVENT_THRESHOLD
     const eventHasEnded = endTime.toMillis() < DateTime.now().toMillis()
 
-    const [windowHeight, setWindowHeight] = useState(0)
+    const [windowHeight, setWindowHeight] = useState(window.innerHeight)
+    const [eventWidth, setEventWidth] = useState(0)
+    useLayoutEffect(() => {
+        if (!eventRef.current) return
+        setEventWidth(eventRef.current.getBoundingClientRect().width)
+    }, [])
     const [coords, setCoords] = useState({
         xCoord: 0,
         yCoord: 0,
@@ -99,6 +104,7 @@ function EventBody(props: EventBodyProps): JSX.Element {
                 xCoord: eventRef.current.getBoundingClientRect().left,
                 yCoord: eventRef.current.getBoundingClientRect().bottom,
             })
+            setEventWidth(eventRef.current.getBoundingClientRect().width)
         }
         setWindowHeight(window.innerHeight)
     }
@@ -121,6 +127,7 @@ function EventBody(props: EventBodyProps): JSX.Element {
                         xCoord={coords.xCoord}
                         yCoord={coords.yCoord}
                         eventHeight={eventBodyHeight}
+                        eventWidth={eventWidth}
                         windowHeight={windowHeight}
                         ref={popupRef}
                     />

--- a/frontend/src/components/molecules/EventDetailPopup-styles.tsx
+++ b/frontend/src/components/molecules/EventDetailPopup-styles.tsx
@@ -2,14 +2,15 @@ import { Border, Colors, Spacing, Typography, Shadows } from '../../styles'
 import NoStyleButton from '../atoms/buttons/NoStyleButton'
 import styled from 'styled-components'
 
-const MAX_POPUP_LENGTH = '315px'
-const MAX_POPUP_HEIGHT = '100px'
+const MAX_POPUP_LENGTH = 315
+const MAX_POPUP_HEIGHT = 100
 
 interface EventBoxStyleProps {
     xCoord: number
     yCoord: number
     popupHeight: number
     eventHeight: number
+    eventWidth: number
     windowHeight: number
 }
 /* Calculates the position of the popup depending on the position of the event
@@ -18,9 +19,11 @@ export const EventBoxStyle = styled.div<EventBoxStyleProps>`
     position: absolute;
     box-sizing: border-box;
     padding: ${Spacing.padding._16} ${Spacing.padding._16};
-    width: ${MAX_POPUP_LENGTH};
-
-    left: calc(${(props) => props.xCoord}px - ${MAX_POPUP_LENGTH});
+    width: ${MAX_POPUP_LENGTH}px;
+    left: ${(props) =>
+        props.xCoord <= MAX_POPUP_LENGTH
+            ? `calc(${props.xCoord}px + ${props.eventWidth}px)`
+            : `calc(${props.xCoord}px - ${MAX_POPUP_LENGTH}px)`};
     top: ${(props) =>
         props.yCoord >= props.windowHeight - props.popupHeight
             ? props.yCoord - props.eventHeight - props.popupHeight
@@ -71,7 +74,7 @@ export const EventDate = styled.span`
 export const Description = styled.div`
     ${Typography.label};
     color: ${Colors.text.black};
-    max-height: ${MAX_POPUP_HEIGHT};
+    max-height: ${MAX_POPUP_HEIGHT}px;
     overflow-wrap: break-word;
     overflow-y: auto;
 `

--- a/frontend/src/components/molecules/EventDetailPopup.tsx
+++ b/frontend/src/components/molecules/EventDetailPopup.tsx
@@ -25,11 +25,12 @@ interface EventDetailProps {
     xCoord: number
     yCoord: number
     eventHeight: number
+    eventWidth: number
     windowHeight: number
 }
 
 const EventDetailPopup = React.forwardRef<HTMLDivElement, EventDetailProps>(
-    ({ event, date, onClose, xCoord, yCoord, eventHeight, windowHeight }: EventDetailProps, ref) => {
+    ({ event, date, onClose, xCoord, yCoord, eventHeight, eventWidth, windowHeight }: EventDetailProps, ref) => {
         const popupRef = useRef<HTMLDivElement | null>(null)
         const [popupHeight, setPopupHeight] = useState(0)
         useLayoutEffect(() => {
@@ -45,6 +46,7 @@ const EventDetailPopup = React.forwardRef<HTMLDivElement, EventDetailProps>(
                 yCoord={yCoord}
                 popupHeight={popupHeight}
                 eventHeight={eventHeight}
+                eventWidth={eventWidth}
                 windowHeight={windowHeight}
                 ref={(node) => {
                     popupRef.current = node


### PR DESCRIPTION
This PR fixes the positioning for the following edge cases: 
- The popup for events on the left-most column doesn't get cut off the screen 
- The popup will always be located on the bottom left corner of the event as default 

[Expected behavior] 
<img width="560" alt="Screen Shot 2022-08-15 at 3 20 47 PM" src="https://user-images.githubusercontent.com/54857128/184728695-904cb6ca-da67-49be-84e8-225b01c09999.png">
