### PR TITLE
Meeting banner fix (fontawesome related)

### DIFF
--- a/frontend/src/components/atoms/buttons/JointMeetingButton.tsx
+++ b/frontend/src/components/atoms/buttons/JointMeetingButton.tsx
@@ -5,7 +5,6 @@ import { TConferenceCall } from '../../../utils/types'
 import styled from 'styled-components'
 import NoStyleButton from './NoStyleButton'
 import NoStyleAnchor from '../NoStyleAnchor'
-import { logos } from '../../../styles/images'
 
 const JoinMeetingButtonContainer = styled(NoStyleButton)`
     height: 30px;
@@ -29,7 +28,7 @@ const JoinMeetingButton = ({ conferenceCall }: JoinMeetingButtonProps) => (
     <NoStyleAnchor href={conferenceCall.url} target="_blank" rel="noreferrer">
         <JoinMeetingButtonContainer>
             <ButtonText>Join</ButtonText>
-            <Icon size="xSmall" icon={logos[conferenceCall.logo]} />
+            <Icon size="xSmall" icon={conferenceCall.logo} />
         </JoinMeetingButtonContainer>
     </NoStyleAnchor>
 )


### PR DESCRIPTION
Because of the new icon system, I need to revert a change made earlier to get meeting banner icons differently.  The backend sends the whole path for the icon instead of just the name.  Ideally, we want the backend to send the name of the icon as the paths might change on the frontend when we do more stuff with the icons.  For now, this is a fix that addresses errors relating to showing the google meet icon.

Backend please fix the endpoint to just send the name of the logo as opposed to the path.

Right now it sends "/images/google-meet.svg" when it should send "google-meet"