### PR TITLE
Re-add vertical border in expanded calendar

### DIFF
--- a/frontend/src/components/calendar/CalendarEvents-styles.tsx
+++ b/frontend/src/components/calendar/CalendarEvents-styles.tsx
@@ -54,6 +54,7 @@ export const CalendarRow = styled.tr`
 export const CalendarTD = styled.td`
     display: block;
     border-top: 1px solid ${CALENDAR_TD_COLOR};
+    border-left: 1px solid ${CALENDAR_TD_COLOR};
     height: 100%;
 `
 export const CalendarCell = styled.div`


### PR DESCRIPTION
Adding the vertical border back into the expanded calendar
Before: 
<img width="1199" alt="Screen Shot 2022-08-17 at 7 19 43 PM" src="https://user-images.githubusercontent.com/54857128/185278539-a3344598-5336-4f50-8a09-433eea8bdc51.png">
After: 
<img width="896" alt="Screen Shot 2022-08-17 at 7 20 46 PM" src="https://user-images.githubusercontent.com/54857128/185278569-c69c97db-1585-40d6-a256-649d5d90a7fc.png">
