### PR TITLE
Don't sentry log the error where the linear task is undone too quickly

### DIFF
--- a/backend/external/linear.go
+++ b/backend/external/linear.go
@@ -324,7 +324,7 @@ func updateLinearIssue(client *graphqlBasic.Client, issueID string, updateFields
 		} else {
 			logger := logging.GetSentryLogger()
 			if task.Status.ExternalID != task.CompletedStatus.ExternalID {
-				logger.Error().Msgf("cannot mark task as undone because its Status does not equal its CompletedStatus, task: %+v", task)
+				log.Error().Msgf("cannot mark task as undone because its Status does not equal its CompletedStatus, task: %+v", task)
 				return nil, fmt.Errorf("cannot mark task as undone because its Status does not equal its CompletedStatus, task: %+v", task)
 			} else if task.PreviousStatus.ExternalID == "" {
 				logger.Error().Msgf("cannot mark task as undone because it does not have a valid PreviousStatus, task: %+v", task)


### PR DESCRIPTION
We had previously discussed also making this a 400 error, but technically it does seem more appropriate as a 503 and fails because the backend hasn't gotten a response yet from Linear vs. the client sending a malformatted error. Curious if you think keeping at 503 is still fine or not. Also, we don't pass through any 4xx errors from external to api, so it would involve a refactor and error type checking (not a problem, just mentioning my thoughts)