### PR TITLE
Order Pull Requests in Github Overview response

### DIFF
--- a/backend/api/overview.go
+++ b/backend/api/overview.go
@@ -436,6 +436,7 @@ func (api *API) GetGithubOverviewResult(db *mongo.Database, ctx context.Context,
 		}
 		pullResults = append(pullResults, &pullRequestResult)
 	}
+	api.sortPullRequestResults(pullResults)
 	result.ViewItems = pullResults
 	return &result, nil
 }

--- a/backend/api/pull_requests_test.go
+++ b/backend/api/pull_requests_test.go
@@ -111,7 +111,7 @@ func TestPullRequestList(t *testing.T) {
 			{
 				ID:   repositoryID1,
 				Name: repositoryName1,
-				PullRequests: []PullRequestResult{
+				PullRequests: []*PullRequestResult{
 					{
 						ID: pullRequest7.ID.Hex(),
 						Status: PullRequestStatus{
@@ -198,7 +198,7 @@ func TestPullRequestList(t *testing.T) {
 			{
 				ID:   repositoryID2,
 				Name: repositoryName2,
-				PullRequests: []PullRequestResult{
+				PullRequests: []*PullRequestResult{
 					{
 						ID: pullRequest10.ID.Hex(),
 						Status: PullRequestStatus{


### PR DESCRIPTION
@anyone Do you see an easy way we can reuse the PR ordering tests from `pull_requests_test.go`. I want to avoid having duplicate code, but I'm having a hard time finding a clean way to share the ordering tests between the two files. Any ideas would be greatly appreciated!