### PR TITLE
Initally fetch pull requests from overview page

### DIFF
--- a/frontend/src/components/views/OverviewPageView.tsx
+++ b/frontend/src/components/views/OverviewPageView.tsx
@@ -13,6 +13,7 @@ import PullRequestDetails from '../details/PullRequestDetails'
 import { SectionHeader } from '../molecules/Header'
 import EmptyDetails from '../details/EmptyDetails'
 import { icons } from '../../styles/images'
+import { useFetchPullRequests } from '../../services/api/pull-request.hooks'
 
 const OverviewPageContainer = styled.div`
     display: flex;
@@ -27,6 +28,7 @@ const ActionsContainer = styled.div`
 
 const OverviewView = () => {
     const { data: views, isLoading, isFetching } = useGetOverviewViews()
+    useFetchPullRequests()
     const { overviewViewId, overviewItemId } = useParams()
     const navigate = useNavigate()
     const scrollRef = useRef<HTMLDivElement>(null)


### PR DESCRIPTION
Previously `/pull_requests/fetch/` was automatically re-fetched in the overview page only after the user went to the pull requests page. This was because the `pull_request_fetch` cache was only initialized in the pull requests page