### PR TITLE
Speed up animation so it finishes before the task disappears

### DIFF
--- a/frontend/src/components/atoms/GTCheckbox.tsx
+++ b/frontend/src/components/atoms/GTCheckbox.tsx
@@ -5,7 +5,7 @@ import checkbox from '../../../public/animations/checkbox.json'
 import styled from 'styled-components'
 import Lottie, { LottieRef } from 'lottie-react'
 
-const ANIM_SPEED = 1.5
+const ANIM_SPEED = 3
 const ANIM_START_FRAME = 3
 const ANIM_END_FRAME = 29
 const ANIM_TOTAL_FRAMES = ANIM_END_FRAME - ANIM_START_FRAME


### PR DESCRIPTION
Was playing around with the settings a bit - curious what others think of a change like this - I feel it's a bit easier to see the full completion animation before the fadeout