### PR TITLE
Fix toast ID import warning

### DIFF
--- a/frontend/src/components/molecules/EventDetailPopup.tsx
+++ b/frontend/src/components/molecules/EventDetailPopup.tsx
@@ -12,7 +12,8 @@ import {
 } from './EventDetailPopup-styles'
 import React, { forwardRef, MouseEvent, useLayoutEffect, useRef, useState } from 'react'
 import { icons, logos } from '../../styles/images'
-import toast, { ToastId, dismissToast } from '../../utils/toast'
+import toast, { dismissToast } from '../../utils/toast'
+import { Id as ToastId } from 'react-toastify'
 
 import { DateTime } from 'luxon'
 import { EVENT_UNDO_TIMEOUT } from '../../constants'

--- a/frontend/src/utils/toast.tsx
+++ b/frontend/src/utils/toast.tsx
@@ -1,9 +1,7 @@
-import { ToastOptions, toast as toastifyToast } from 'react-toastify'
+import { Id as ToastId, ToastOptions, toast as toastifyToast } from 'react-toastify'
 import ToastTemplate, { ToastTemplateProps } from '../components/atoms/toast/ToastTemplate'
 
 import React from 'react'
-
-type ToastId = string | number
 
 const toast = (toastTemplateProps: ToastTemplateProps, options?: ToastOptions): ToastId => {
     return toastifyToast(<ToastTemplate {...toastTemplateProps} />, options)
@@ -16,5 +14,5 @@ const updateToast = (id: ToastId, toastTemplateProps: ToastTemplateProps, option
 const dismissToast = toastifyToast.dismiss
 const isActive = toastifyToast.isActive
 
-export { ToastId, updateToast, isActive, dismissToast }
+export { updateToast, isActive, dismissToast }
 export default toast


### PR DESCRIPTION
`WARNING in ./src/utils/toast.tsx 14:0-56
export 'Id' (reexported as 'ToastId') was not found in 'react-toastify' (possible exports: Bounce, Flip, Icons, Slide, ToastContainer, Zoom, collapseToast, cssTransition, toast, useToast, useToastContainer)`