### PR TITLE
Modify events with correct account ID

### DIFF
--- a/frontend/src/components/calendar/utils/useCalendarDrop.ts
+++ b/frontend/src/components/calendar/utils/useCalendarDrop.ts
@@ -107,7 +107,7 @@ const useCalendarDrop = ({
                 modifyEvent({
                     event: item.event,
                     payload: {
-                        account_id: primaryAccountID,
+                        account_id: item.event.account_id,
                         datetime_start: dropTime.toISO(),
                         datetime_end: end.toISO(),
                     },
@@ -125,7 +125,7 @@ const useCalendarDrop = ({
                 modifyEvent({
                     event: item.event,
                     payload: {
-                        account_id: primaryAccountID,
+                        account_id: item.event.account_id,
                         datetime_end: end.toISO(),
                     },
                     date,

--- a/frontend/src/services/api/events.hooks.ts
+++ b/frontend/src/services/api/events.hooks.ts
@@ -114,10 +114,12 @@ export const useCreateEvent = () => {
                     id: uuidv4(),
                     title: createEventPayload.summary ?? '',
                     body: createEventPayload.description ?? '',
+                    account_id: createEventPayload.account_id,
                     logo: linkedTask?.source.logo_v2 ?? 'gcal',
                     deeplink: '',
                     datetime_start: createEventPayload.datetime_start,
                     datetime_end: createEventPayload.datetime_end,
+                    can_modify: false,
                     conference_call: {
                         url: '',
                         logo: '',

--- a/frontend/src/utils/types.ts
+++ b/frontend/src/utils/types.ts
@@ -83,10 +83,12 @@ export interface TEvent {
     id: string
     title: string
     body: string
+    account_id: string
     logo: TLogoImage
     deeplink: string
     datetime_start: string
     datetime_end: string
+    can_modify: boolean
     conference_call: TConferenceCall
     linked_task_id: string
 }


### PR DESCRIPTION
Send /events/modify request with corresponding account ID of the event instead of the "primary" account ID