### PR TITLE
Update modal overlay to cover entire app

### DIFF
--- a/frontend/src/components/atoms/GTModal.tsx
+++ b/frontend/src/components/atoms/GTModal.tsx
@@ -61,6 +61,9 @@ const SHARED_MODAL_CONTENT_STYLE = {
 }
 
 const getModalStyle = (modalSize: TModalSize): Modal.Styles => ({
+    overlay: {
+        zIndex: 1000,
+    },
     content: {
         ...SHARED_MODAL_CONTENT_STYLE,
         maxHeight: Dimensions.modalSize[modalSize].max_height,


### PR DESCRIPTION
This also fixes the bug that caused the modals to be cutoff by the navbar/calendar views.

Before:
<img width="1640" alt="Screen Shot 2022-09-09 at 9 09 51 AM" src="https://user-images.githubusercontent.com/9156543/189394300-a85f0675-edc5-4644-9057-1c1877094d34.png">
After:
<img width="1640" alt="Screen Shot 2022-09-09 at 9 08 31 AM" src="https://user-images.githubusercontent.com/9156543/189394309-82d3a96b-ef2d-4c2f-b9a2-cd5be8eb389a.png">

Fixes FRO-455