### PR TITLE
Fix conditional requests (they never actually worked before lol)

### DIFF
--- a/backend/external/github_pr.go
+++ b/backend/external/github_pr.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
-	"math"
 	"net/http"
 	"net/url"
 	"strings"
@@ -369,7 +367,6 @@ func pullRequestHasBeenModified(db *mongo.Database, ctx context.Context, userID 
 	// Github API does not support conditional requests, so this logic is required
 	request, _ := http.NewRequest("GET", requestURL, nil)
 	request.Header.Set("Accept", "application/vnd.github+json")
-	fmt.Println("token:", token)
 	if token != nil {
 		request.Header.Set("Authorization", "token "+token.AccessToken)
 	}
@@ -383,12 +380,6 @@ func pullRequestHasBeenModified(db *mongo.Database, ctx context.Context, userID 
 		return true, dbPR
 	}
 
-	fmt.Println("status code:", resp.StatusCode)
-	body, err := ioutil.ReadAll(resp.Body)
-	if err == nil {
-
-		fmt.Println("body:", string(body)[:int(math.Min(float64(150), float64(len(string(body)))))])
-	}
 	return (resp.StatusCode != http.StatusNotModified), dbPR
 }
 


### PR DESCRIPTION
We were previously sending a `nil` token to the conditional request function because the `token` within the if statement was a separate variable initialized in a new scope 