### PR TITLE
Add ability to override calendar shadow + fix calendar shadow bug

### DIFF
--- a/frontend/src/components/calendar/CalendarEvents-styles.tsx
+++ b/frontend/src/components/calendar/CalendarEvents-styles.tsx
@@ -81,11 +81,9 @@ export const EventBodyStyle = styled.div.attrs<EventBodyStyleProps>((props) => (
         width: getEventWidth(props.squishFactor),
         height: props.eventBodyHeight - EVENT_BOTTOM_PADDING,
         top: props.topOffset,
-        left: `calc(
-            100% - ${TABLE_WIDTH_PERCENTAGE} + ${CELL_LEFT_MARGIN} + (${getEventWidth(props.squishFactor)}) * ${
+        left: `calc(100% - ${TABLE_WIDTH_PERCENTAGE} + ${CELL_LEFT_MARGIN} + (${getEventWidth(props.squishFactor)}) * ${
             props.leftOffset
-        }
-        )`,
+        })`,
         opacity: props.eventHasEnded && !props.isBeingDragged ? 0.5 : 1,
         zIndex: props.isBeingDragged ? 1 : 0,
     },
@@ -162,14 +160,14 @@ export const DayHeaderText = styled.div<{ isToday: boolean }>`
     background-color: ${(props) => (props.isToday ? Colors.gtColor.primary : Colors.background.medium)};
     ${Typography.body};
 `
-export const CalendarContainer = styled.div<{ expanded: boolean; hasShadow: boolean }>`
+export const CalendarContainer = styled.div<{ isExpanded: boolean; showShadow: boolean }>`
     min-width: 300px;
     height: 100%;
-    flex: ${(props) => (props.expanded ? '1' : '0')};
+    flex: ${(isExpanded) => (isExpanded ? '1' : '0')};
     background-color: ${Colors.background.medium};
     display: flex;
     z-index: 1;
-    box-shadow: ${Shadows.light};
+    box-shadow: ${({ showShadow }) => (showShadow ? Shadows.light : 'none')};
     flex-direction: column;
 `
 export const DayAndHeaderContainer = styled.div`

--- a/frontend/src/components/views/CalendarView.tsx
+++ b/frontend/src/components/views/CalendarView.tsx
@@ -1,17 +1,16 @@
-import CalendarHeader from '../calendar/CalendarHeader'
-import { memo, useEffect, useMemo, useState } from 'react'
-
-import { CalendarContainer } from '../calendar/CalendarEvents-styles'
-import CalendarEvents from '../calendar/CalendarEvents'
-import { DateTime } from 'luxon'
-import { getMonthsAroundDate } from '../../utils/time'
-import { useGetLinkedAccounts } from '../../services/api/settings.hooks'
-import { useGetEvents } from '../../services/api/events.hooks'
-import { useIdleTimer } from 'react-idle-timer'
 import { useInterval } from '../../hooks'
 import useKeyboardShortcut from '../../hooks/useKeyboardShortcut'
+import { useGetEvents } from '../../services/api/events.hooks'
+import { useGetLinkedAccounts } from '../../services/api/settings.hooks'
+import { getMonthsAroundDate } from '../../utils/time'
 import { useCalendarContext } from '../calendar/CalendarContext'
+import CalendarEvents from '../calendar/CalendarEvents'
+import { CalendarContainer } from '../calendar/CalendarEvents-styles'
+import CalendarHeader from '../calendar/CalendarHeader'
 import CollapsedCalendarSidebar from '../calendar/CollapsedCalendarSidebar'
+import { DateTime } from 'luxon'
+import { memo, useEffect, useMemo, useState } from 'react'
+import { useIdleTimer } from 'react-idle-timer'
 
 export type TCalendarType = 'day' | 'week'
 
@@ -20,8 +19,15 @@ interface CalendarViewProps {
     showMainHeader?: boolean
     showDateHeader?: boolean
     isInitiallyCollapsed?: boolean
+    showContainerShadow?: boolean
 }
-const CalendarView = ({ initialType, showMainHeader, showDateHeader, isInitiallyCollapsed }: CalendarViewProps) => {
+const CalendarView = ({
+    initialType,
+    showMainHeader,
+    showDateHeader,
+    isInitiallyCollapsed,
+    showContainerShadow = true,
+}: CalendarViewProps) => {
     const timeoutTimer = useIdleTimer({}) // default timeout is 20 minutes
     const [date, setDate] = useState<DateTime>(DateTime.now())
     const monthBlocks = useMemo(() => {
@@ -61,7 +67,10 @@ const CalendarView = ({ initialType, showMainHeader, showDateHeader, isInitially
     return isCollapsed ? (
         <CollapsedCalendarSidebar onClick={() => setIsCollapsed(false)} />
     ) : (
-        <CalendarContainer expanded={calendarType === 'week'} hasShadow={isTaskDraggingOverDetailsView}>
+        <CalendarContainer
+            isExpanded={calendarType === 'week'}
+            showShadow={isTaskDraggingOverDetailsView && showContainerShadow}
+        >
             <CalendarHeader date={date} setDate={setDate} />
             <CalendarEvents date={date} primaryAccountID={primaryAccountID} />
         </CalendarContainer>


### PR DESCRIPTION
We need to override calendar shadow for focus mode. Also I noticed that the shadow wasn't being hidden when `isTaskDraggingOverDetailsView` is `false`.