### PR TITLE
Add hover state to folder icon

### DIFF
--- a/frontend/src/components/molecules/ActionOption.tsx
+++ b/frontend/src/components/molecules/ActionOption.tsx
@@ -1,31 +1,18 @@
 import { useCallback, useEffect, useRef } from 'react'
-
-import ActionValue from '../atoms/ActionValue'
-import { Icon } from '../atoms/Icon'
-import { KEYBOARD_SHORTCUTS, TKeyboardShortcuts } from '../../constants'
-import SectionEditor from './SectionEditor'
-import NoStyleButton from '../atoms/buttons/NoStyleButton'
-
-import { Spacing } from '../../styles'
-import { TTask } from '../../utils/types'
-import { icons } from '../../styles/images'
+import * as ReactDOMServer from 'react-dom/server'
 import styled from 'styled-components'
+import { KEYBOARD_SHORTCUTS, TKeyboardShortcuts } from '../../constants'
 import { useClickOutside } from '../../hooks'
 import useKeyboardShortcut from '../../hooks/useKeyboardShortcut'
-import TooltipWrapper from '../atoms/TooltipWrapper'
+import { Spacing } from '../../styles'
+import { icons } from '../../styles/images'
+import { TTask } from '../../utils/types'
 import { KeyboardShortcutContainer } from '../atoms/KeyboardShortcut'
-import * as ReactDOMServer from 'react-dom/server'
+import TooltipWrapper from '../atoms/TooltipWrapper'
+import GTIconButton from '../atoms/buttons/GTIconButton'
+import SectionEditor from './SectionEditor'
 
 const ButtonAndPopoverContainer = styled.div`
-    position: relative;
-`
-const ActionButton = styled(NoStyleButton)`
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    justify-content: center;
-    padding: ${Spacing._4};
-    margin-right: ${Spacing._8};
     position: relative;
 `
 
@@ -71,21 +58,18 @@ const ActionOption = ({ task, isShown, keyboardShortcut, setIsShown }: ActionOpt
         !isShown
     )
 
-    const { icon, popover, actionString } = (() => {
+    const { icon, popover } = (() => {
         return {
             icon: icons.folder,
             popover: <SectionEditor task_id={task.id} closeSectionEditor={() => setIsShown(false)} />,
-            actionString: '',
         }
     })()
 
     return (
         <ButtonAndPopoverContainer ref={actionRef}>
-            <ActionButton onClick={() => setIsShown(!isShown)}>
-                <TooltipWrapper inline dataTip={section} tooltipId="tooltip">
-                    {actionString ? <ActionValue value={actionString} /> : <Icon icon={icon} size="small" />}
-                </TooltipWrapper>
-            </ActionButton>
+            <TooltipWrapper inline dataTip={section} tooltipId="tooltip">
+                <GTIconButton icon={icon} size="small" onClick={() => setIsShown(!isShown)} />
+            </TooltipWrapper>
             {isShown && popover}
         </ButtonAndPopoverContainer>
     )


### PR DESCRIPTION
This adds a hover state to the folder action option by refactoring it slightly to use the new GTIconButton.
<img width="232" alt="Screen Shot 2022-09-12 at 5 10 29 PM" src="https://user-images.githubusercontent.com/31417618/189779908-89d4a85f-52d6-4c87-bf5a-d9490c93af64.png">
