### PR TITLE
Make fake lag much shorter

### DIFF
--- a/backend/api/utils.go
+++ b/backend/api/utils.go
@@ -153,7 +153,7 @@ func Handle500(c *gin.Context) {
 
 func FakeLagMiddleware(c *gin.Context) {
 	if isLocalServer() {
-		time.Sleep(0.5 * time.Second)
+		time.Sleep(time.Second / 2)
 	}
 }
 


### PR DESCRIPTION
Based on feedback from frontend engineers, we should make the fake lag less annoying so people don't feel the need to disable it when testing, defeating the purpose of its existence. This makes it 4x shorter.