### PR TITLE
Remove unused assignee fields from Linear query to reduce complexity

### DIFF
--- a/backend/external/linear.go
+++ b/backend/external/linear.go
@@ -229,10 +229,7 @@ type linearAssignedIssuesQuery struct {
 			CreatedAt   graphql.String
 			Priority    graphql.Float
 			Assignee    struct {
-				Id          graphql.ID
-				Name        graphql.String
-				DisplayName graphql.String
-				Email       graphql.String
+				Email graphql.String
 			}
 			Team struct {
 				Name               graphql.String

--- a/backend/external/linear_task_test.go
+++ b/backend/external/linear_task_test.go
@@ -33,10 +33,6 @@ func TestLoadLinearTasks(t *testing.T) {
 						"url": "https://example.com/",
 						"createdAt": "2022-06-06T23:13:24.037Z",
 						"priority": 3.0,
-						"assignee": {
-							"id": "6942069420",
-							"name": "Test User"
-						},
 						"state": {
 							"id": "state-id",
 							"name": "Todo",


### PR DESCRIPTION
The assignee fields other than email were unused, so I removed them to (slightly) reduce the query's complexity.