### PR TITLE
hide scrollbars

### DIFF
--- a/frontend/src/components/views/NavigationView.tsx
+++ b/frontend/src/components/views/NavigationView.tsx
@@ -1,7 +1,7 @@
 import { useDrop } from 'react-dnd'
 import { useNavigate } from 'react-router-dom'
 import styled from 'styled-components'
-import { Colors, Shadows, Spacing } from '../../styles'
+import { Colors, Shadows, Snippets, Spacing } from '../../styles'
 import { logos } from '../../styles/images'
 import { DropType } from '../../utils/types'
 import { Icon } from '../atoms/Icon'
@@ -29,6 +29,7 @@ const NavigationViewHeader = styled.div`
 const OverflowContainer = styled.div`
     flex: 1;
     overflow: auto;
+    ${Snippets.hideScrollbars};
 `
 const GapView = styled.div`
     display: flex;

--- a/frontend/src/styles/index.ts
+++ b/frontend/src/styles/index.ts
@@ -6,5 +6,6 @@ import * as Screens from './screens'
 import * as Shadows from './shadows'
 import * as Spacing from './spacing'
 import * as Typography from './typography'
+import * as Snippets from './snippets'
 
-export { Colors, Typography, Images, Screens, Shadows, Dimensions, Border, Spacing }
+export { Colors, Typography, Images, Screens, Shadows, Dimensions, Border, Spacing, Snippets }

--- a/frontend/src/styles/snippets.ts
+++ b/frontend/src/styles/snippets.ts
@@ -1,0 +1,9 @@
+import { css } from 'styled-components'
+
+export const hideScrollbars = css`
+    scrollbar-width: none;      // Firefox
+    -ms-overflow-style: none;   // IE and Edge
+    ::-webkit-scrollbar {       // Chrome, Safari, and Opera
+        display: none;
+    }
+`


### PR DESCRIPTION
Hide the scrollbar in the navigation menu. This **isn't** done with absolute positioning, but instead with just hiding the actual scrollbar elements per browser.  Also includes a nice css snippet so that we can do this easily elsewhere with just one line. Eventually, we can use this snippet in combination with a **custom** scrollbar to make our app even more fancy fancy

![image](https://user-images.githubusercontent.com/31417618/191129187-d9f4c509-4df1-4bb1-b606-9711fa8ac76c.png)
