### PR TITLE
Introduce initial request logging for event methods

### DIFF
--- a/backend/api/router.go
+++ b/backend/api/router.go
@@ -9,15 +9,6 @@ import (
 	ginSwagger "github.com/swaggo/gin-swagger"
 )
 
-var RoutePrefixesToLogInDetail = [...]string{
-	"/tasks/create_external/slack/",
-	"/events/create/",
-	"/events/delete/",
-	"/events/modify/",
-	"/tasks/create/",
-	"/tasks/modify/",
-}
-
 func GetRouter(handlers *API) *gin.Engine {
 	// Setting release mode has the benefit of reducing spam on the unit test output
 	gin.SetMode(gin.ReleaseMode)

--- a/backend/api/utils.go
+++ b/backend/api/utils.go
@@ -155,15 +155,6 @@ func isLocalServer() bool {
 
 func LogRequestMiddleware(db *mongo.Database) func(c *gin.Context) {
 	return func(c *gin.Context) {
-		matchesRoute := false
-		for _, route := range RoutePrefixesToLogInDetail {
-			if strings.HasPrefix(c.Request.URL.Path, route) {
-				matchesRoute = true
-			}
-		}
-		if !matchesRoute {
-			return
-		}
 		startTime := time.Now()
 
 		// runs the rest of the request
@@ -184,11 +175,12 @@ func LogRequestMiddleware(db *mongo.Database) func(c *gin.Context) {
 			objectID, err := primitive.ObjectIDFromHex(id)
 			if err != nil {
 				// This means the task ID is improperly formatted
-				log.Debug().Err(err).Msgf("could not parse object_id=%s", objectID)
+				log.Error().Err(err).Msgf("could not parse object_id=%s", objectID)
 				return
 			}
 		}
 
-		database.LogRequestInfo(db, startTime, userObjectID, c.Request.URL.Path, time.Now().UnixMilli()-startTime.UnixMilli(), &objectID)
+		status := c.Writer.Status()
+		database.LogRequestInfo(db, startTime, userObjectID, c.Request.URL.Path, time.Now().UnixMilli()-startTime.UnixMilli(), &objectID, status)
 	}
 }

--- a/backend/database/helpers.go
+++ b/backend/database/helpers.go
@@ -728,12 +728,13 @@ func AdjustOrderingIDsForCollection(collection *mongo.Collection, userID primiti
 	return nil
 }
 
-func LogRequestInfo(db *mongo.Database, timestamp time.Time, userID primitive.ObjectID, method string, latencyMS int64, objectID *primitive.ObjectID) {
+func LogRequestInfo(db *mongo.Database, timestamp time.Time, userID primitive.ObjectID, method string, latencyMS int64, objectID *primitive.ObjectID, statusCode int) {
 	requestInfo := ServerRequestInfo{
-		Timestamp: primitive.NewDateTimeFromTime(timestamp),
-		UserID:    userID,
-		Method:    method,
-		LatencyMS: latencyMS,
+		Timestamp:  primitive.NewDateTimeFromTime(timestamp),
+		UserID:     userID,
+		Method:     method,
+		LatencyMS:  latencyMS,
+		StatusCode: statusCode,
 	}
 	if objectID != nil {
 		requestInfo.ObjectID = *objectID

--- a/backend/database/helpers_test.go
+++ b/backend/database/helpers_test.go
@@ -980,7 +980,7 @@ func TestLogRequestInfo(t *testing.T) {
 	taskID := primitive.NewObjectID()
 
 	t.Run("Success", func(t *testing.T) {
-		LogRequestInfo(db, time.Now(), userID, "/testing/", 100, &taskID)
+		LogRequestInfo(db, time.Now(), userID, "/testing/", 100, &taskID, 200)
 		collection := GetServerRequestCollection(db)
 		cursor, err := collection.Find(context.Background(), bson.M{"user_id": userID})
 		assert.NoError(t, err)

--- a/backend/database/models.go
+++ b/backend/database/models.go
@@ -266,6 +266,7 @@ type ServerRequestInfo struct {
 	ObjectID      primitive.ObjectID `bson:"object_id,omitempty"` // can be task, event, pull_request, section, etc.
 	SourceID      string             `bson:"source_id,omitempty"`
 	TimeToCloseMS int64              `bson:"time_to_close_ms,omitempty"` // only will be populated when a task is completed
+	StatusCode    int                `bson:"status_code,omitempty"`
 }
 
 type TaskSection struct {


### PR DESCRIPTION
This is an initial PR for the introduction of logging across our requests. Some notes: 
- I have introduced the fewest number of fields possible in order to minimize the size of each of these logs. As of right now, the size of these logs is ~100 bytes, which I believe should be manageable.
- I have limited the scope of this logging to object modification/creation/deletion. I do not think the refreshes are as valuable, and for each endpoint it will be (assuming the user leaves General Task open the whole day): 100 bytes * 4 times a minute * 60 minutes * 24 hours = 576 kilobytes / day. This is not scaleable beyond a few users. If we have even 1000 users, this will be 576 MB per day (too much!). And I'm not sure how much info we'd gain from these refreshes.
- We are using Mongo instead of Prometheus to serve this data. This was because I felt it overkill to create another database when we already have one in place and working. Grafana will integrate just fine with this.