### PR TITLE
Create atomic component for external links 

### DIFF
--- a/frontend/src/components/atoms/buttons/ExternalLinkButton.tsx
+++ b/frontend/src/components/atoms/buttons/ExternalLinkButton.tsx
@@ -1,0 +1,16 @@
+import { icons } from '../../../styles/images'
+import NoStyleAnchor from '../NoStyleAnchor'
+import GTIconButton from './GTIconButton'
+
+interface ExternalLinkButtonProps {
+    link: string
+}
+const ExternalLinkButton = ({ link }: ExternalLinkButtonProps) => {
+    return (
+        <NoStyleAnchor href={link} target="_blank" rel="noreferrer">
+            <GTIconButton icon={icons.external_link} size="small" />
+        </NoStyleAnchor>
+    )
+}
+
+export default ExternalLinkButton

--- a/frontend/src/components/details/PullRequestDetails.tsx
+++ b/frontend/src/components/details/PullRequestDetails.tsx
@@ -1,10 +1,9 @@
 import styled from 'styled-components'
 import { Colors, Spacing, Typography } from '../../styles'
-import { icons, logos } from '../../styles/images'
+import { logos } from '../../styles/images'
 import { TPullRequest } from '../../utils/types'
 import { Icon } from '../atoms/Icon'
-import NoStyleAnchor from '../atoms/NoStyleAnchor'
-import GTIconButton from '../atoms/buttons/GTIconButton'
+import ExternalLinkButton from '../atoms/buttons/ExternalLinkButton'
 import BranchName from '../pull-requests/BranchName'
 import { Status } from '../pull-requests/styles'
 import DetailsViewTemplate from '../templates/DetailsViewTemplate'
@@ -56,9 +55,7 @@ const PullRequestDetails = ({ pullRequest }: PullRequestDetailsProps) => {
                 <DetailsTopContainer>
                     <Icon icon={logos.github} size="small" color={Colors.icon.black} />
                     <MarginLeftAuto>
-                        <NoStyleAnchor href={deeplink} target="_blank" rel="noreferrer">
-                            <GTIconButton icon={icons.external_link} size="small" />
-                        </NoStyleAnchor>
+                        <ExternalLinkButton link={deeplink} />
                     </MarginLeftAuto>
                 </DetailsTopContainer>
                 <TitleContainer>{title}</TitleContainer>

--- a/frontend/src/components/pull-requests/PullRequest.tsx
+++ b/frontend/src/components/pull-requests/PullRequest.tsx
@@ -5,8 +5,7 @@ import { icons } from '../../styles/images'
 import { TPullRequest } from '../../utils/types'
 import { getHumanTimeSinceDateTime } from '../../utils/utils'
 import { Icon } from '../atoms/Icon'
-import NoStyleAnchor from '../atoms/NoStyleAnchor'
-import GTButton from '../atoms/buttons/GTButton'
+import ExternalLinkButton from '../atoms/buttons/ExternalLinkButton'
 import { SubtitleSmall } from '../atoms/subtitle/Subtitle'
 import { Column, CommentsCountContainer, LinkButtonContainer, PullRequestRow, Status, TruncatedText } from './styles'
 
@@ -44,9 +43,7 @@ const PullRequest = ({ pullRequest, link, isSelected }: PullRequestProps) => {
             </Column>
             <Column type="link">
                 <LinkButtonContainer>
-                    <NoStyleAnchor href={deeplink} target="_blank" rel="noreferrer">
-                        <GTButton icon={icons.external_link} styleType="secondary" />
-                    </NoStyleAnchor>
+                    <ExternalLinkButton link={deeplink} />
                 </LinkButtonContainer>
             </Column>
         </PullRequestRow>

--- a/frontend/src/styles/images.ts
+++ b/frontend/src/styles/images.ts
@@ -5,7 +5,6 @@ import {
     faArrowRotateRight,
     faArrowUp,
     faArrowUpRightAndArrowDownLeftFromCenter,
-    faArrowUpRightFromSquare,
     faCalendar,
     faCalendarDays,
     faCheck,
@@ -20,6 +19,7 @@ import {
     faXmark,
 } from '@fortawesome/pro-regular-svg-icons'
 import {
+    faArrowUpRightFromSquare,
     faBadgeCheck,
     faBars,
     faChevronDown,


### PR DESCRIPTION
\+ replace fa icon with light version

See rightmost icon:
Before
<img width="485" alt="Screen Shot 2022-09-23 at 11 00 00 AM" src="https://user-images.githubusercontent.com/9156543/191991164-ac956064-fe16-47f0-a383-da3a4d177493.png">
After
<img width="500" alt="Screen Shot 2022-09-23 at 10 59 22 AM" src="https://user-images.githubusercontent.com/9156543/191991044-a85ae049-ec48-4c21-9f22-7a7c4294cc8b.png">
