### PR TITLE
Fix radix menu widths

### DIFF
--- a/frontend/src/components/radix/GTPopover.tsx
+++ b/frontend/src/components/radix/GTPopover.tsx
@@ -7,6 +7,7 @@ const PopoverTrigger = styled(Popover.Trigger)`
 `
 const PopoverContent = styled(Popover.Content)`
     ${MenuContentShared};
+    width: unset;
 `
 
 interface GTPopoverProps {

--- a/frontend/src/components/radix/RadixUIConstants.ts
+++ b/frontend/src/components/radix/RadixUIConstants.ts
@@ -3,6 +3,8 @@ import { Spacing, Border, Colors, Shadows, Typography } from '../../styles'
 import { TIconColor, TTextColor } from '../../styles/colors'
 import { TIconType } from '../atoms/Icon'
 
+const MENU_WIDTH = '172px'
+
 export const MenuItemShared = css<{ $isSelected?: boolean; $textColor?: TTextColor }>`
     display: flex;
     align-items: center;
@@ -24,6 +26,7 @@ export const MenuItemShared = css<{ $isSelected?: boolean; $textColor?: TTextCol
 `
 export const MenuContentShared = css`
     z-index: 5;
+    width: ${MENU_WIDTH};
     ${Typography.body};
     padding: ${Spacing._4};
     background-color: ${Colors.background.white};


### PR DESCRIPTION
I had removed the constant `DROPDOWN_MENU_WIDTH` because it was used in the shared style and it wasn't wide enough to fit the calendar popover, but that had unintended side-effects elsewhere (such as making the "add new account" dropdown menu incredibly wide with an oversized sign-in-with-google button.  I've added it back now, and just unset the width specifically for the calendar dropdown.