### PR TITLE
Only break words in headers when necessary

### DIFF
--- a/frontend/src/components/molecules/Header.tsx
+++ b/frontend/src/components/molecules/Header.tsx
@@ -35,7 +35,7 @@ const HeaderButton = styled(NoStyleButton)`
 `
 const HeaderText = styled.div<{ fontColor: TTextColor }>`
     color: ${({ fontColor }) => Colors.text[fontColor]};
-    word-break: break-all;
+    word-break: break-word;
     text-align: left;
     padding: ${Spacing._8};
     ${Typography.title};


### PR DESCRIPTION
Previously, headers would break on characters. Now, it will break on words and only break words when the word is too long to fit on a line by itself.

![image](https://user-images.githubusercontent.com/31417618/192404007-215c0f10-70c1-4ff2-92ac-467f9b0df292.png)
