### PR TITLE
Always show event time in calendar event body

### DIFF
--- a/frontend/src/components/calendar/CalendarEvents-styles.tsx
+++ b/frontend/src/components/calendar/CalendarEvents-styles.tsx
@@ -116,13 +116,14 @@ export const EventInfo = styled.div<{ isLongEvent: boolean }>`
         `
             : 'flex-direction: row;'}
 `
-export const EventTitle = styled.div`
+export const EventIconAndTitle = styled.div`
     display: flex;
     align-items: center;
     gap: ${Spacing._8};
-    margin-right: ${Spacing._8};
     max-height: 100%;
     min-width: 0;
+`
+export const EventTitle = styled.div`
     text-overflow: ellipsis;
     overflow: hidden;
     white-space: nowrap;

--- a/frontend/src/components/calendar/EventBody.tsx
+++ b/frontend/src/components/calendar/EventBody.tsx
@@ -9,6 +9,7 @@ import {
     CELL_HEIGHT_VALUE,
     EventBodyStyle,
     EventFill,
+    EventIconAndTitle,
     EventInfo,
     EventInfoContainer,
     EventTime,
@@ -123,14 +124,14 @@ function EventBody(props: EventBodyProps): JSX.Element {
                     />
                 )}
                 <EventInfo isLongEvent={isLongEvent}>
-                    <EventTitle>
+                    <EventIconAndTitle>
                         {props.event.linked_task_id && (
                             <IconContainer>
                                 <Icon size="xSmall" icon={logos[props.event.logo]} />
                             </IconContainer>
                         )}
-                        {props.event.title || '(no title)'}
-                    </EventTitle>
+                        <EventTitle>{props.event.title || '(no title)'}</EventTitle>
+                    </EventIconAndTitle>
                     <EventTime>{`${startTimeString} - ${endTimeString}`}</EventTime>
                 </EventInfo>
             </EventInfoContainer>


### PR DESCRIPTION
Show the event time and truncate the event title if necessary

[updated]

![image](https://user-images.githubusercontent.com/42781446/192564087-794082e3-b10d-4bb6-a792-e22548ca14aa.png)
