### PR TITLE
Disable drag for events the user cannot modify

### DIFF
--- a/frontend/src/components/calendar/EventBodyDraggable.tsx
+++ b/frontend/src/components/calendar/EventBodyDraggable.tsx
@@ -13,7 +13,6 @@ interface EventBodyDraggableProps {
     children: ReactNode
 }
 const EventBodyDraggable = ({ event, children }: EventBodyDraggableProps) => {
-    console.log({ event })
     const [isDragging, drag, dragPreview] = useDrag(
         () => ({
             type: DropType.EVENT,

--- a/frontend/src/components/calendar/ResizeHandle.tsx
+++ b/frontend/src/components/calendar/ResizeHandle.tsx
@@ -24,6 +24,7 @@ const ResizeHandle = ({ event }: ResizeHandleProps) => {
         () => ({
             type: DropType.EVENT_RESIZE_HANDLE,
             item: { event },
+            canDrag: event.can_modify,
             collect: (monitor) => monitor.isDragging(),
         }),
         [event]


### PR DESCRIPTION
We'll probably want a better experience in the future but for now this prevents users from rescheduling events they are not allowed to modify