### PR TITLE
Move menu width to the item instead of the content

### DIFF
--- a/frontend/src/components/radix/RadixUIConstants.ts
+++ b/frontend/src/components/radix/RadixUIConstants.ts
@@ -3,12 +3,13 @@ import { Spacing, Border, Colors, Shadows, Typography } from '../../styles'
 import { TIconColor, TTextColor } from '../../styles/colors'
 import { TIconType } from '../atoms/Icon'
 
-const MENU_WIDTH = '172px'
+const MENU_WIDTH = '152px'
 
 export const MenuItemShared = css<{ $isSelected?: boolean; $textColor?: TTextColor }>`
     display: flex;
     align-items: center;
     gap: ${Spacing._12};
+    width: ${MENU_WIDTH};
     flex: 1;
     margin: ${Spacing._4} 0;
     padding: ${Spacing._4} ${Spacing._12};
@@ -26,7 +27,6 @@ export const MenuItemShared = css<{ $isSelected?: boolean; $textColor?: TTextCol
 `
 export const MenuContentShared = css`
     z-index: 5;
-    width: ${MENU_WIDTH};
     ${Typography.body};
     padding: ${Spacing._4};
     background-color: ${Colors.background.white};


### PR DESCRIPTION
This fixes the bad width of the calendar within the context menu. In theory, this should be better for differently sized content in dropdowns + context menus.