### PR TITLE
Remove meeting prep tasks from Default section results

### DIFF
--- a/backend/api/task_list_v3.go
+++ b/backend/api/task_list_v3.go
@@ -153,7 +153,7 @@ func (api *API) extractSectionTasksV3(
 			}
 		}
 		if !addedToSection && !taskResult.IsMeetingPreparationTask {
-			// add to "Today" section if task section id is not found
+			// add to "Default" section if task section id is not found
 			resultSections[0].Tasks = append(resultSections[0].Tasks, taskResult)
 		}
 	}


### PR DESCRIPTION
This is a very small change to remove the meeting prep tasks from Default. 

There are currently no tests for task_list_v3, and so writing entirely new tests simply to test this one aspect feels a little out of whack. I would like to create a regression test at some point though.