### PR TITLE
Use custom font-family for buttons, inputs, and textareas

### DIFF
--- a/frontend/src/styles/GlobalStyle.ts
+++ b/frontend/src/styles/GlobalStyle.ts
@@ -13,6 +13,12 @@ const GlobalStyle = createGlobalStyle`
         font-family: -apple-system, BlinkMacSystemFont, sans-serif, 'Segoe UI', Helvetica, Roboto, Oxygen, Ubuntu, Cantarell,
             Arial, 'Fira Sans', 'Droid Sans', 'Helvetica Neue', 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
     }
+    button,
+    input,
+    textarea {
+        font-family: -apple-system, BlinkMacSystemFont, sans-serif, 'Segoe UI', Helvetica, Roboto, Oxygen, Ubuntu, Cantarell,
+            Arial, 'Fira Sans', 'Droid Sans', 'Helvetica Neue', 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+    }
     a {
         color: ${Colors.text.purple};
     }

--- a/frontend/src/styles/typography.ts
+++ b/frontend/src/styles/typography.ts
@@ -29,56 +29,44 @@ const weight = {
     semibold: '590',
     bold: '700',
 }
-const GTFontFamily = css`
-    font-family: -apple-system, BlinkMacSystemFont, sans-serif, 'Segoe UI', Helvetica, Roboto, Oxygen, Ubuntu,
-            Cantarell, Arial, 'Fira Sans', 'Droid Sans', 'Helvetica Neue', 'Apple Color Emoji', 'Segoe UI Emoji',
-            'Segoe UI Symbol' !important;
-`
 
 export const header = css`
-    ${GTFontFamily};
     font-size: ${fontSize.xxl}; // 48px
     line-height: ${lineHeight.xl}; // 56px
     font-weight: ${weight.bold}; // 700
     letter-spacing: -0.02em; // -2%
 `
 export const title = css`
-    ${GTFontFamily};
     font-size: ${fontSize.xl}; // 32px
     line-height: ${lineHeight.l}; // 40px
     font-weight: ${weight.semibold}; // 590
     letter-spacing: -0.01em; // -1%
 `
 export const subtitle = css`
-    ${GTFontFamily};
     font-size: ${fontSize.l}; // 20px
     line-height: ${lineHeight.m}; // 24px
     font-weight: ${weight.medium}; // 510
     letter-spacing: -0.01em; // -1%
 `
 export const body = css`
-    ${GTFontFamily};
     font-size: ${fontSize.m}; // 16px
     line-height: ${lineHeight.m}; // 24px
     font-weight: ${weight.regular}; // 400
     letter-spacing: -0.01em; // -1%
 `
 export const bodySmall = css`
-    ${GTFontFamily};
     font-size: ${fontSize.s}; // 14px
     line-height: ${lineHeight.m}; // 24px
     font-weight: ${weight.regular}; // 400
     letter-spacing: -0.01em; // -1%
 `
 export const label = css`
-    ${GTFontFamily};
     font-size: ${fontSize.xs}; // 12px
     line-height: ${lineHeight.s}; // 16px
     font-weight: ${weight.regular}; // 400
     letter-spacing: -0.01em; // -1%
 `
 export const eyebrow = css`
-    ${GTFontFamily};
     font-size: ${fontSize.xs}; // 12px
     line-height: ${lineHeight.s}; // 16px
     font-weight: ${weight.regular}; // 400
@@ -86,7 +74,6 @@ export const eyebrow = css`
     text-transform: uppercase; // UPPERCASE
 `
 export const mini = css`
-    ${GTFontFamily};
     font-size: ${fontSize.xxs}; // 10px
     line-height: ${lineHeight.xs}; // 14px
     font-weight: ${weight.regular}; // 400


### PR DESCRIPTION
Before (chrome):
<img width="170" alt="Screen Shot 2022-09-27 at 4 25 21 PM" src="https://user-images.githubusercontent.com/31417618/192655240-3c646818-3fc5-4a3c-88bc-10b0ec92d58d.png">
After (also chrome):
<img width="174" alt="Screen Shot 2022-09-27 at 4 28 48 PM" src="https://user-images.githubusercontent.com/31417618/192655288-8af39d37-6b88-4d67-a086-62e3dca26076.png">
(this issue was only on chrome)
(chrome is a bad browser, firefox is better)
(everyone should switch to firefox)
(google is removing adblocking from the next chrome release so people will be moving to firefox anyway because chrome is getting worse with each and every update)
(google bad)