### PR TITLE
Add copyright watermark + make sidebar buttons smaller

### DIFF
--- a/frontend/src/components/molecules/FeedbackButton.tsx
+++ b/frontend/src/components/molecules/FeedbackButton.tsx
@@ -9,6 +9,7 @@ const FeedbackButton = () => {
             <GTButton
                 value="Share feedback"
                 styleType="secondary"
+                size="small"
                 fitContent={false}
                 onClick={() => setModalIsOpen(true)}
             />

--- a/frontend/src/components/views/NavigationView.tsx
+++ b/frontend/src/components/views/NavigationView.tsx
@@ -1,7 +1,7 @@
 import { useDrop } from 'react-dnd'
 import { useNavigate } from 'react-router-dom'
 import styled from 'styled-components'
-import { Colors, Shadows, Spacing } from '../../styles'
+import { Colors, Shadows, Spacing, Typography } from '../../styles'
 import { logos } from '../../styles/images'
 import { DropType } from '../../utils/types'
 import { Icon } from '../atoms/Icon'
@@ -43,6 +43,12 @@ const GapView = styled.div`
     padding-bottom: ${Spacing._8};
     margin-top: auto;
 `
+const CopyrightText = styled.span`
+    margin-top: ${Spacing._4};
+    text-align: center;
+    color: ${Colors.text.placeholder};
+    ${Typography.eyebrow};
+`
 
 const NavigationView = () => {
     const navigate = useNavigate()
@@ -70,6 +76,7 @@ const NavigationView = () => {
                 <GTButton
                     value="Account settings"
                     styleType="secondary"
+                    size="small"
                     fitContent={false}
                     onClick={() => {
                         setCalendarType('day')
@@ -77,6 +84,7 @@ const NavigationView = () => {
                     }}
                 />
             </GapView>
+            <CopyrightText>© GeneralTask 2022</CopyrightText>
         </NavigationViewContainer>
     )
 }


### PR DESCRIPTION
To fit with new design doc. Design for reference:
<img width="313" alt="Screen Shot 2022-09-28 at 4 00 02 PM" src="https://user-images.githubusercontent.com/31417618/192903166-a968e386-9d17-4f95-990d-1a4fe27de5af.png">

And our app:
<img width="146" alt="Screen Shot 2022-09-28 at 4 00 43 PM" src="https://user-images.githubusercontent.com/31417618/192903224-86b4ed4d-ba3c-4abd-84fe-16132c4b862a.png">
