### PR TITLE
Preload focus mode background image in main app

### DIFF
--- a/frontend/src/components/screens/MainScreen.tsx
+++ b/frontend/src/components/screens/MainScreen.tsx
@@ -7,6 +7,7 @@ import { DateTime } from 'luxon'
 import { useEventBanners } from '../../hooks'
 import { useGetTasks } from '../../services/api/tasks.hooks'
 import { useGetUserInfo } from '../../services/api/user-info.hooks'
+import { focusModeBackground } from '../../styles/images'
 import Loading from '../atoms/Loading'
 import DragLayer from '../molecules/DragLayer'
 import DefaultTemplate from '../templates/DefaultTemplate'
@@ -47,6 +48,7 @@ const MainScreen = () => {
 
     return (
         <DndProvider backend={HTML5Backend}>
+            <link rel="preload" as="image" href={focusModeBackground} />
             <DefaultTemplate>
                 <>{currentPage}</>
             </DefaultTemplate>


### PR DESCRIPTION

https://user-images.githubusercontent.com/42781446/193096224-6719c878-ac7f-473c-9034-cbfdec194db0.mp4

This image will still take some time to load if the user directly goes to /focus-mode but this is an unlikely use case