### PR TITLE
Change default folder to use inbox icon

### DIFF
--- a/frontend/src/components/navigation_sidebar/NavigationSectionLinks.tsx
+++ b/frontend/src/components/navigation_sidebar/NavigationSectionLinks.tsx
@@ -154,7 +154,7 @@ const NavigationSectionLinks = () => {
                     <NavigationLink
                         link={`/tasks/${defaultFolder.id}`}
                         title={defaultFolder.name}
-                        icon={icons.folder}
+                        icon={icons.inbox}
                         isCurrentPage={sectionId === defaultFolder.id}
                         taskSection={defaultFolder}
                         count={defaultFolder.tasks.length}


### PR DESCRIPTION
Note: the other thing that needs to happen is making the default folder named "Task Inbox" by default. This is a backend change and will only affect new accounts made after this change. @alfaindia 