### PR TITLE
Fix next task selection when marking as done or moving task

### DIFF
--- a/frontend/src/components/views/TaskSectionView.tsx
+++ b/frontend/src/components/views/TaskSectionView.tsx
@@ -56,6 +56,7 @@ const TaskSectionView = () => {
     }, [taskSections, params.task, params.section])
 
     const taskIndex = useMemo(() => {
+        // Find the index of the currently selected task. If the task is not found, return 0
         const index = section?.tasks.findIndex(({ id }) => id === task?.id)
         return !index || index === -1 ? 0 : index
     }, [params.task, params.section])


### PR DESCRIPTION
When marking a task as done or moving it out of the section, the behavior is now:
1. If the task isn't the last in the list, select the task that replaces it's position.
2. If the task IS the last in the list, select the next-to-last task.
3. If there is only one task left, select it.
4. If there are no tasks, don't select anything. You have no more tasks.