### PR TITLE
Only show time indicator in week view or when it is today

### DIFF
--- a/frontend/src/components/calendar/CalendarEvents.tsx
+++ b/frontend/src/components/calendar/CalendarEvents.tsx
@@ -3,7 +3,7 @@ import { DateTime } from 'luxon'
 import styled from 'styled-components'
 import { useGetEvents } from '../../services/api/events.hooks'
 import { useGetLinkedAccounts } from '../../services/api/settings.hooks'
-import { getMonthsAroundDate } from '../../utils/time'
+import { getMonthsAroundDate, isDateToday } from '../../utils/time'
 import { TEvent, TLinkedAccount } from '../../utils/types'
 import ConnectIntegration from '../molecules/ConnectIntegration'
 import { useCalendarContext } from './CalendarContext'
@@ -96,14 +96,13 @@ const WeekCalendarEvents = ({ date, groups, primaryAccountID }: WeekCalendarEven
         eventsContainerRef,
         isWeekView: isWeekCalendar,
     })
+    const isToday = isDateToday(date)
 
     return (
         <DayAndHeaderContainer ref={eventsContainerRef}>
             {isWeekCalendar && (
                 <CalendarDayHeader>
-                    <DayHeaderText isToday={date.startOf('day').equals(DateTime.now().startOf('day'))}>
-                        {date.toFormat('ccc dd')}
-                    </DayHeaderText>
+                    <DayHeaderText isToday={isToday}>{date.toFormat('ccc dd')}</DayHeaderText>
                 </CalendarDayHeader>
             )}
             <DayContainer>
@@ -122,7 +121,7 @@ const WeekCalendarEvents = ({ date, groups, primaryAccountID }: WeekCalendarEven
                     ) : (
                         <DropPreview isVisible={isOver} offset={EVENT_CREATION_INTERVAL_HEIGHT * dropPreviewPosition} />
                     ))}
-                <TimeIndicator />
+                {(isWeekCalendar || isToday) && <TimeIndicator />}
                 <CalendarDayTable hasBorder={isWeekCalendar} />
             </DayContainer>
         </DayAndHeaderContainer>
@@ -192,7 +191,7 @@ const CalendarEvents = ({ date, primaryAccountID }: CalendarEventsProps) => {
             <TimeAndHeaderContainer>
                 {calendarType == 'week' && <CalendarDayHeader />}
                 <TimeContainer>
-                    <TimeIndicator ref={timeIndicatorRef} />
+                    {isDateToday(date) && <TimeIndicator ref={timeIndicatorRef} />}
                     <CalendarTimeTable />
                 </TimeContainer>
             </TimeAndHeaderContainer>

--- a/frontend/src/utils/time.ts
+++ b/frontend/src/utils/time.ts
@@ -24,3 +24,7 @@ export function getDiffBetweenISOTimes(start: string, end: string) {
     const endDateTime = DateTime.fromISO(end)
     return endDateTime.diff(startDateTime)
 }
+
+export function isDateToday(date: DateTime) {
+    return date.hasSame(DateTime.local(), 'day')
+}


### PR DESCRIPTION
Also made a functional change: in the week view, only show the indicator on today. This follow's Hans' guiding principle of "Do what google does"

https://user-images.githubusercontent.com/42781446/193396041-be5a661c-50f2-4696-8a57-f27657c5c152.mov

