### PR TITLE
Fix event time overflow bug

### DIFF
--- a/frontend/src/components/calendar/CalendarEvents-styles.tsx
+++ b/frontend/src/components/calendar/CalendarEvents-styles.tsx
@@ -133,6 +133,8 @@ export const EventTime = styled.div`
     float: left;
     max-height: 100%;
     white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 `
 export const EventFill = styled.div<{ squareStart: boolean; squareEnd: boolean; isSelected: boolean }>`
     width: 100%;


### PR DESCRIPTION
Before:
<img width="254" alt="Screen Shot 2022-10-02 at 12 51 12 PM" src="https://user-images.githubusercontent.com/9156543/193466102-0e9749c0-2717-477d-bebd-bb1fd37ba66b.png">
After:
<img width="228" alt="Screen Shot 2022-10-02 at 12 51 02 PM" src="https://user-images.githubusercontent.com/9156543/193466101-500133af-9a9c-4bc3-825b-3c04fd83549b.png">

