### PR TITLE
Reorder context menu

### DIFF
--- a/frontend/src/components/radix/TaskContextMenuWrapper.tsx
+++ b/frontend/src/components/radix/TaskContextMenuWrapper.tsx
@@ -71,7 +71,6 @@ const TaskContextMenuWrapper = ({ task, sectionId, children }: TaskContextMenuPr
             ],
         },
         {
-            //
             label: sectionId !== TRASH_SECTION_ID ? 'Delete Task' : 'Restore Task',
             icon: icons.trash,
             iconColor: 'red',


### PR DESCRIPTION
it makes more sense to group them like this imo 
<img width="515" alt="image" src="https://user-images.githubusercontent.com/97246822/194119544-e9cf8553-15f8-4996-aef8-99fa71176a96.png">
