### PR TITLE
Hide overfow text + show alt text on hover

### DIFF
--- a/frontend/src/components/atoms/GTHeader.tsx
+++ b/frontend/src/components/atoms/GTHeader.tsx
@@ -3,5 +3,6 @@ import { Typography } from '../../styles'
 
 const GTHeader = styled.div`
     ${Typography.header}
+    overflow: hidden;
 `
 export default GTHeader

--- a/frontend/src/components/screens/FocusModeScreen.tsx
+++ b/frontend/src/components/screens/FocusModeScreen.tsx
@@ -258,7 +258,7 @@ const FocusModeScreen = () => {
                             )}
                             {chosenEvent && (
                                 <>
-                                    <GTHeader>{title}</GTHeader>
+                                    <GTHeader title={title}>{title}</GTHeader>
                                     <GTTitle>
                                         <TimeRange start={timeStart} end={timeEnd} />
                                     </GTTitle>


### PR DESCRIPTION
<img width="1914" alt="Screen Shot 2022-10-05 at 12 52 27 PM" src="https://user-images.githubusercontent.com/9156543/194139485-7aad8ea0-0bd7-4d1b-8f1e-f543d812f9e5.png">
