### PR TITLE
Truncate minutes to avoid floats in time text

### DIFF
--- a/frontend/src/components/screens/FocusModeScreen.tsx
+++ b/frontend/src/components/screens/FocusModeScreen.tsx
@@ -130,7 +130,7 @@ const RightAbsoluteContainer = styled.div`
 const getTimeUntilNextEvent = (event: TEvent) => {
     const now = DateTime.local()
     const eventStart = DateTime.fromISO(event.datetime_start)
-    const minutesUntilEvent = eventStart.diff(now, 'minutes').minutes
+    const minutesUntilEvent = Math.floor(eventStart.diff(now, 'minutes').minutes)
     if (minutesUntilEvent === 1) {
         return '1 minute'
     } else if (minutesUntilEvent < 60) {


### PR DESCRIPTION
Fixes the following bug:
<img width="258" alt="Screen Shot 2022-10-05 at 12 55 54 PM" src="https://user-images.githubusercontent.com/9156543/194139975-d57e228e-ee3a-4166-bcf9-5feb98a2b548.png">
