### PR TITLE
Send ordering_id when creating a new folder

### DIFF
--- a/frontend/src/components/navigation_sidebar/NavigationSectionLinks.tsx
+++ b/frontend/src/components/navigation_sidebar/NavigationSectionLinks.tsx
@@ -53,7 +53,7 @@ const NavigationSectionLinks = () => {
         e.stopPropagation()
         if (e.key === 'Enter' && sectionName.trim() !== '') {
             setSectionName('')
-            addTaskSection({ name: sectionName })
+            addTaskSection({ name: sectionName, id_ordering: folders?.length })
             setIsAddSectionInputVisible(false)
         } else if (e.key === 'Escape' && inputRef.current) {
             setSectionName('')

--- a/frontend/src/services/api/task-section.hooks.ts
+++ b/frontend/src/services/api/task-section.hooks.ts
@@ -3,11 +3,12 @@ import produce, { castImmutable } from 'immer'
 import { TASK_SECTION_DEFAULT_ID } from '../../constants'
 import apiClient from '../../utils/api'
 import { TTaskSection } from '../../utils/types'
-import { useGTQueryClient } from '../queryUtils'
 import { arrayMoveInPlace } from '../../utils/utils'
+import { useGTQueryClient } from '../queryUtils'
 
 interface TAddTaskSectionData {
     name: string
+    id_ordering?: number
 }
 
 interface TModifyTaskSectionData {


### PR DESCRIPTION
otherwise the folder gets created at the top, even though the text field is at the bottom of the folders