### PR TITLE
Stop up/down keys from blurring task create input

### DIFF
--- a/frontend/src/components/molecules/CreateNewTask.tsx
+++ b/frontend/src/components/molecules/CreateNewTask.tsx
@@ -42,7 +42,7 @@ const Tooltip = styled.div`
     ${Typography.bodySmall};
 `
 
-const blurShortcuts = [KEYBOARD_SHORTCUTS.arrowUp.key, KEYBOARD_SHORTCUTS.arrowDown.key, KEYBOARD_SHORTCUTS.close.key]
+const blurShortcuts = [KEYBOARD_SHORTCUTS.close.key]
 
 interface CreateNewTaskProps {
     sectionId: string


### PR DESCRIPTION
turns out this was intended behavior :woozy: