### PR TITLE
Fix very minor unicode issue

### DIFF
--- a/frontend/src/components/focus-mode/FlexTime.tsx
+++ b/frontend/src/components/focus-mode/FlexTime.tsx
@@ -143,8 +143,8 @@ const FlexTime = ({ nextEvent }: FlexTimeProps) => {
                 <TimeRange start={fifteenMinuteBlock} end={nextEventTime} />
             </GTTitle>
             <Subtitle>
-                If you need something to work on, we've picked a couple tasks that you may be interested in doing now.
-                You can click either one to get started, or have us pick a couple other options for you.
+                If you need something to work on, we&apos;ve picked a couple tasks that you may be interested in doing
+                now. You can click either one to get started, or have us pick a couple other options for you.
                 <br />
                 <br />
                 Remember, you can always schedule tasks by dragging them onto the calendar before entering Focus Mode.


### PR DESCRIPTION
Warning: The character U+2019 "’" could be confused with the character U+0060 "`", which is more common in source code.