### PR TITLE
Make dropdown/context menus highlight parent when nested

### DIFF
--- a/frontend/src/components/radix/RadixUIConstants.ts
+++ b/frontend/src/components/radix/RadixUIConstants.ts
@@ -21,6 +21,10 @@ export const MenuItemShared = css<{ $isSelected?: boolean; $textColor?: TTextCol
         outline: ${Border.stroke.small} solid ${Colors.border.light};
         background-color: ${Colors.background.medium};
     }
+    &[data-state='open'] {
+        outline: ${Border.stroke.small} solid ${Colors.border.light};
+        background-color: ${Colors.background.medium};
+    }
 `
 export const MenuContentShared = css`
     z-index: 5;


### PR DESCRIPTION
Before, it would only highlight when hovered. Now it highlights the trigger for the submenu.

<img width="527" alt="Screen Shot 2022-10-06 at 1 08 27 PM" src="https://user-images.githubusercontent.com/31417618/194398196-02e843b0-5fc4-4fe8-9971-e3be282fd7ef.png">
