### PR TITLE
Gap between calendar header buttons is the same (8px)

### DIFF
--- a/frontend/src/components/calendar/CalendarHeader.tsx
+++ b/frontend/src/components/calendar/CalendarHeader.tsx
@@ -33,11 +33,12 @@ const HeaderBodyContainer = styled.div`
 const ButtonContainer = styled.div`
     display: flex;
     align-items: center;
-    gap: 5px;
+    gap: ${Spacing._8};
 `
 const HeaderIconsContainer = styled.div`
     display: flex;
     align-items: center;
+    gap: ${Spacing._8};
 `
 const CalendarDateText = styled.div`
     ${Typography.subtitle};


### PR DESCRIPTION
<img width="305" alt="Screen Shot 2022-10-06 at 3 53 09 PM" src="https://user-images.githubusercontent.com/31417618/194425503-ba8b16c3-ec1a-4d6f-aae9-48085af26765.png">
