### PR TITLE
Always show time range in event body

### DIFF
--- a/frontend/src/components/calendar/CalendarEvents-styles.tsx
+++ b/frontend/src/components/calendar/CalendarEvents-styles.tsx
@@ -141,6 +141,7 @@ export const EventTime = styled.div`
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+    min-width: fit-content;
 `
 export const EventFill = styled.div<{ squareStart: boolean; squareEnd: boolean; isSelected: boolean }>`
     width: 100%;


### PR DESCRIPTION
Before
<img width="235" alt="Screen Shot 2022-10-06 at 5 00 03 PM" src="https://user-images.githubusercontent.com/9156543/194433679-395461b3-e1ee-4054-af3e-32d33ba877e9.png">
After
<img width="235" alt="Screen Shot 2022-10-06 at 4 59 09 PM" src="https://user-images.githubusercontent.com/9156543/194433675-57e5e8bc-e70f-4f4b-9a81-bd632dd771d9.png">