### PR TITLE
Maintain pressed down state of dropdown menus in task details when dropdown is open

### DIFF
--- a/frontend/src/components/atoms/buttons/GTButton.tsx
+++ b/frontend/src/components/atoms/buttons/GTButton.tsx
@@ -33,7 +33,7 @@ const SecondaryButtonStyles = css`
         color: ${Colors.button.secondary.active_text};
     }
 `
-const SimpleButtonStyles = css`
+const SimpleButtonStyles = css<{ active?: boolean }>`
     background-color: inherit;
     color: ${Colors.text.light};
     &:hover {
@@ -43,6 +43,10 @@ const SimpleButtonStyles = css`
         background-color: ${Colors.background.light};
         outline: ${Border.stroke.small} solid ${Colors.border.light};
     }
+    ${({ active }) =>
+        active &&
+        `background-color: ${Colors.background.light};
+        outline: ${Border.stroke.small} solid ${Colors.border.light};`}
 `
 const LargeButtonStyle = css`
     padding: ${Spacing._8} ${Spacing._16};
@@ -61,6 +65,7 @@ const Button = styled(NoStyleButton)<{
     fitContent: boolean
     size: TButtonSize
     textColor?: TTextColor
+    active?: boolean
 }>`
     display: flex;
     justify-content: center;
@@ -103,6 +108,7 @@ interface GTButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
     iconColor?: TIconColor
     textColor?: TTextColor
     fitContent?: boolean
+    active?: boolean
     isDropdown?: boolean
     asDiv?: boolean
 }
@@ -115,6 +121,7 @@ const GTButton = ({
     iconColor,
     textColor,
     value,
+    active,
     isDropdown = false,
     asDiv = false,
     ...rest
@@ -126,6 +133,7 @@ const GTButton = ({
             wrapText={wrapText}
             fitContent={fitContent}
             textColor={textColor}
+            active={active}
             as={asDiv ? 'div' : 'button'}
             {...rest}
         >

--- a/frontend/src/components/atoms/buttons/GTIconButton.tsx
+++ b/frontend/src/components/atoms/buttons/GTIconButton.tsx
@@ -10,7 +10,7 @@ import { KeyboardShortcutContainer } from '../KeyboardShortcut'
 import TooltipWrapper from '../TooltipWrapper'
 import NoStyleButton from './NoStyleButton'
 
-const Button = styled(NoStyleButton)<{ forceShowHoverEffect?: boolean }>`
+const Button = styled(NoStyleButton)<{ forceShowHoverEffect?: boolean; active?: boolean }>`
     padding: ${Spacing._8};
     border-radius: 50%;
     :hover {

--- a/frontend/src/components/molecules/GTDatePicker.tsx
+++ b/frontend/src/components/molecules/GTDatePicker.tsx
@@ -130,6 +130,7 @@ const GTDatePicker = ({ initialDate, setDate, showIcon = true, onlyCalendar = fa
                     textColor={getFormattedDate(value).textColor}
                     iconColor={getFormattedDate(value).iconColor}
                     onClick={() => setIsOpen(!isOpen)}
+                    active={isOpen}
                     asDiv
                 />
             }

--- a/frontend/src/components/radix/FolderDropdown.tsx
+++ b/frontend/src/components/radix/FolderDropdown.tsx
@@ -1,0 +1,54 @@
+import { useState } from 'react'
+import { useGetTasks, useReorderTask } from '../../services/api/tasks.hooks'
+import { icons } from '../../styles/images'
+import { TTask } from '../../utils/types'
+import { getSectionFromTask } from '../../utils/utils'
+import GTIconButton from '../atoms/buttons/GTIconButton'
+import GTDropdownMenu from './GTDropdownMenu'
+
+interface FolderDropdownProps {
+    task: TTask
+}
+const FolderDropdown = ({ task }: FolderDropdownProps) => {
+    const [isOpen, setIsOpen] = useState(false)
+    const { data: taskSections } = useGetTasks(false)
+    const { mutate: reorderTask } = useReorderTask()
+
+    const sectionId = taskSections && getSectionFromTask(taskSections, task.id)?.id
+
+    return (
+        <GTDropdownMenu
+            isOpen={isOpen}
+            setIsOpen={setIsOpen}
+            items={
+                taskSections
+                    ? taskSections
+                          .filter((s) => !s.is_done && !s.is_trash)
+                          .map((section) => ({
+                              label: section.name,
+                              icon: icons.folder,
+                              selected: section.id === sectionId,
+                              onClick: () => {
+                                  reorderTask({
+                                      taskId: task.id,
+                                      dropSectionId: section.id,
+                                      dragSectionId: sectionId,
+                                      orderingId: 1,
+                                  })
+                              },
+                          }))
+                    : []
+            }
+            trigger={
+                <GTIconButton
+                    icon={icons.folder}
+                    onClick={() => setIsOpen(!isOpen)}
+                    forceShowHoverEffect={isOpen}
+                    asDiv
+                />
+            }
+        />
+    )
+}
+
+export default FolderDropdown

--- a/frontend/src/components/radix/GTDropdownMenu.tsx
+++ b/frontend/src/components/radix/GTDropdownMenu.tsx
@@ -21,14 +21,16 @@ interface GTDropdownMenuProps {
     items: GTMenuItem[] | GTMenuItem[][] // allow for divided groups of items
     trigger: React.ReactNode // component that opens the dropdown menu when clicked
     align?: 'start' | 'end'
+    isOpen?: boolean
+    setIsOpen?: React.Dispatch<React.SetStateAction<boolean>>
 }
 
-const GTDropdownMenu = ({ items, trigger, align = 'start' }: GTDropdownMenuProps) => {
+const GTDropdownMenu = ({ items, trigger, align = 'start', isOpen, setIsOpen }: GTDropdownMenuProps) => {
     const groups = (items.length > 0 && Array.isArray(items[0]) ? items : [items]) as GTMenuItem[][]
 
     return (
         <div onKeyDown={(e) => e.stopPropagation()}>
-            <DropdownMenu.Root>
+            <DropdownMenu.Root modal open={isOpen} onOpenChange={setIsOpen}>
                 <DropdownMenuTrigger>{trigger}</DropdownMenuTrigger>
                 <DropdownMenu.Portal>
                     <DropdownMenuContent align={align}>

--- a/frontend/src/components/radix/LinearStatusDropdown.tsx
+++ b/frontend/src/components/radix/LinearStatusDropdown.tsx
@@ -1,0 +1,43 @@
+import { useState } from 'react'
+import { useModifyTask } from '../../services/api/tasks.hooks'
+import { linearStatus } from '../../styles/images'
+import { TTask } from '../../utils/types'
+import GTButton from '../atoms/buttons/GTButton'
+import GTDropdownMenu from './GTDropdownMenu'
+
+interface LinearStatusDropdownProps {
+    task: TTask
+}
+const LinearStatusDropdown = ({ task }: LinearStatusDropdownProps) => {
+    const [isOpen, setIsOpen] = useState(false)
+    const { mutate: modifyTask } = useModifyTask()
+
+    const status = task.external_status ? task.external_status.state : ''
+    if (!task.external_status || !task.all_statuses) return <></>
+    return (
+        <GTDropdownMenu
+            isOpen={isOpen}
+            setIsOpen={setIsOpen}
+            items={task.all_statuses.map((status) => ({
+                label: status.state,
+                onClick: () => modifyTask({ id: task.id, status: status }),
+                icon: linearStatus[status.type],
+                selected: status.state === task.external_status?.state,
+            }))}
+            trigger={
+                <GTButton
+                    value={status}
+                    icon={linearStatus[task.external_status.type]}
+                    size="small"
+                    styleType="simple"
+                    isDropdown
+                    onClick={() => setIsOpen(!isOpen)}
+                    active={isOpen}
+                    asDiv
+                />
+            }
+        />
+    )
+}
+
+export default LinearStatusDropdown

--- a/frontend/src/components/radix/PriorityDropdown.tsx
+++ b/frontend/src/components/radix/PriorityDropdown.tsx
@@ -1,0 +1,42 @@
+import { useState } from 'react'
+import { TASK_PRIORITIES } from '../../constants'
+import { useModifyTask } from '../../services/api/tasks.hooks'
+import { TTask } from '../../utils/types'
+import GTButton from '../atoms/buttons/GTButton'
+import GTDropdownMenu from './GTDropdownMenu'
+
+interface PriorityDropdownProps {
+    task: TTask
+}
+const PriorityDropdown = ({ task }: PriorityDropdownProps) => {
+    const [isOpen, setIsOpen] = useState(false)
+    const { mutate: modifyTask } = useModifyTask()
+
+    return (
+        <GTDropdownMenu
+            isOpen={isOpen}
+            setIsOpen={setIsOpen}
+            items={TASK_PRIORITIES.map((priority, val) => ({
+                label: priority.label,
+                onClick: () => modifyTask({ id: task.id, priorityNormalized: val }),
+                icon: priority.icon,
+                iconColor: TASK_PRIORITIES[val].color,
+                selected: val === task.priority_normalized,
+            }))}
+            trigger={
+                <GTButton
+                    value={TASK_PRIORITIES[task.priority_normalized].label}
+                    icon={TASK_PRIORITIES[task.priority_normalized].icon}
+                    size="small"
+                    styleType="simple"
+                    iconColor={TASK_PRIORITIES[task.priority_normalized].color}
+                    onClick={() => setIsOpen(!isOpen)}
+                    active={isOpen}
+                    asDiv
+                />
+            }
+        />
+    )
+}
+
+export default PriorityDropdown


### PR DESCRIPTION
The cleanest way to do this for all the dropdowns is to extract them and put them in their own files. Probably.
<img width="255" alt="Screen Shot 2022-10-06 at 5 26 26 PM" src="https://user-images.githubusercontent.com/31417618/194436134-231e933b-5265-4406-b837-d643e4ef5285.png">
