### PR TITLE
Make connect button in google calendar not block due date view

### DIFF
--- a/frontend/src/components/calendar/CalendarHeader.tsx
+++ b/frontend/src/components/calendar/CalendarHeader.tsx
@@ -18,7 +18,6 @@ const RelativeDiv = styled.div`
     position: relative;
 `
 const ConnectContainer = styled.div`
-    position: absolute;
     width: 100%;
     z-index: 100;
 `


### PR DESCRIPTION
<img width="280" alt="Screen Shot 2022-10-06 at 6 14 43 PM" src="https://user-images.githubusercontent.com/9156543/194440652-e57bf5d4-fc22-4fe5-bf2c-10b68416ff4a.png">
