### PR TITLE
Update linear comment styles

### DIFF
--- a/frontend/src/components/details/linear/LinearComment.tsx
+++ b/frontend/src/components/details/linear/LinearComment.tsx
@@ -10,18 +10,20 @@ const TopContainer = styled.div`
     gap: ${Spacing._8};
     padding: ${Spacing._4};
     color: ${Colors.text.black};
-    ${Typography.bodySmall};
     margin-bottom: ${Spacing._16};
 `
 const BodyContainer = styled.div`
     padding: ${Spacing._4};
     margin-bottom: ${Spacing._32};
+    ${Typography.bodySmall};
 `
 const UsernameText = styled.div`
+    ${Typography.bodySmall};
     ${Typography.bold};
 `
 const GrayText = styled.span`
     color: ${Colors.text.light};
+    ${Typography.bodySmall};
 `
 
 interface LinearCommentProps {

--- a/frontend/src/styles/typography.ts
+++ b/frontend/src/styles/typography.ts
@@ -84,5 +84,5 @@ export const mini = css`
     font-weight: ${weight.regular}; // 400
 `
 export const bold = css`
-    font-weight: ${weight.bold};
+    font-weight: ${weight.medium}; // 510
 `


### PR DESCRIPTION
Previously they were way too bold, and the comments were using the wrong typography.
<img width="659" alt="Screen Shot 2022-10-06 at 6 55 14 PM" src="https://user-images.githubusercontent.com/31417618/194443979-e06af236-3b06-4df5-b7c4-b3b4f9b94e68.png">
