### PR TITLE
Linear-like sorting for statuses & color information

### DIFF
--- a/backend/api/task_list.go
+++ b/backend/api/task_list.go
@@ -24,6 +24,7 @@ type externalStatus struct {
 	IDExternal string `json:"external_id,omitempty"`
 	State      string `json:"state,omitempty"`
 	Type       string `json:"type,omitempty"`
+	Color      string `json:"color,omitempty"`
 }
 
 type MeetingPreparationParams struct {
@@ -312,6 +313,7 @@ func (api *API) taskBaseToTaskResult(t *database.Task, userID primitive.ObjectID
 				IDExternal: status.ExternalID,
 				State:      status.State,
 				Type:       status.Type,
+				Color:      status.Color,
 			})
 		}
 		taskResult.AllStatuses = allStatuses

--- a/backend/api/task_list_test.go
+++ b/backend/api/task_list_test.go
@@ -55,6 +55,7 @@ func TestTaskBaseToTaskResult(t *testing.T) {
 			ExternalID: "example ID",
 			State:      "example state",
 			Type:       "example type",
+			Color:      "#ffffff",
 		}
 		slackMessageParams := database.SlackMessageParams{
 			Channel: database.SlackChannel{
@@ -88,6 +89,7 @@ func TestTaskBaseToTaskResult(t *testing.T) {
 		assert.Equal(t, priority, result.PriorityNormalized)
 		assert.Equal(t, 1, len(result.AllStatuses))
 		assert.Equal(t, externalStatus.Type, result.AllStatuses[0].Type)
+		assert.Equal(t, externalStatus.Color, result.AllStatuses[0].Color)
 	})
 }
 

--- a/backend/database/models.go
+++ b/backend/database/models.go
@@ -234,6 +234,7 @@ type ExternalTaskStatus struct {
 	Type              string  `json:"type" bson:"type"`
 	IsCompletedStatus bool    `json:"is_completed_status" bson:"is_completed_status"`
 	Position          float64 `json:"position" bson:"position"`
+	Color             string  `json:"color" bson:"color"`
 }
 
 type UserSetting struct {

--- a/backend/external/linear_task_test.go
+++ b/backend/external/linear_task_test.go
@@ -76,6 +76,14 @@ func TestLoadLinearTasks(t *testing.T) {
 			"workflowStates": {
 				"nodes": [
 					{
+						"id": "6942069419",
+						"name": "Triage",
+						"type": "triage",
+						"team": {
+							"name": "Backend"
+						}
+					},
+					{
 						"id": "6942069420",
 						"name": "Todo",
 						"type": "started",
@@ -283,6 +291,7 @@ func TestLoadLinearTasks(t *testing.T) {
 		assert.NoError(t, err)
 		assertTasksEqual(t, &expectedTask, &taskFromDB)
 		assert.Equal(t, "sample_account@email.com", taskFromDB.SourceAccountID) // doesn't get updated
+		assert.Equal(t, "Triage", taskFromDB.AllStatuses[2].State)
 	})
 	t.Run("SuccessExistingTask", func(t *testing.T) {
 		linearTask := LinearTaskSource{Linear: LinearService{


### PR DESCRIPTION
With the color information, the frontend should have all of the info required to recreate the In Progress logo (and properly color any other status).

Also, sorts the states like how Linear does it: 
<img width="221" alt="Screen Shot 2022-10-07 at 11 51 08 AM" src="https://user-images.githubusercontent.com/34839963/194619417-556a6e4e-19a8-4fe6-a143-a0ba79403726.png">
