### PR TITLE
Fix text overflow bug in calendar

### DIFF
--- a/frontend/src/components/calendar/CalendarEvents-styles.tsx
+++ b/frontend/src/components/calendar/CalendarEvents-styles.tsx
@@ -142,7 +142,7 @@ export const EventTime = styled.div`
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-    min-width: fit-content;
+    min-width: 0;
 `
 export const EventFill = styled.div<{ squareStart: boolean; squareEnd: boolean; isSelected: boolean }>`
     width: 100%;


### PR DESCRIPTION
This is not a perfect solution since some of the text incorrectly truncates, but it is a good temporary solution.

Before
<img width="202" alt="Screen Shot 2022-10-08 at 7 20 07 PM" src="https://user-images.githubusercontent.com/9156543/194734575-43ad1c5f-30b8-4bf9-8c72-d754199f3ec2.png">
After
<img width="218" alt="Screen Shot 2022-10-08 at 7 20 15 PM" src="https://user-images.githubusercontent.com/9156543/194734576-a9a84d98-68dd-4a11-861a-9cab4f2a3483.png">