### PR TITLE
Hide link button in toolbar

### DIFF
--- a/frontend/src/components/atoms/GTTextField/MarkdownEditor/RichTextToolbar.tsx
+++ b/frontend/src/components/atoms/GTTextField/MarkdownEditor/RichTextToolbar.tsx
@@ -51,7 +51,6 @@ const RichTextToolbar = () => {
             {/* TODO: will add this back with full link functionality */}
             {/* <ToolbarButton icon={icons.link} action={emptyFunction} isActive={active.link()} title="Add link" /> */}
             {/* <Divider /> */}
-
             <ToolbarButton
                 icon={icons.list_ol}
                 action={commands.toggleOrderedList}


### PR DESCRIPTION
Hide link button in toolbar until functionality is complete

<img width="576" alt="image" src="https://user-images.githubusercontent.com/42781446/195181431-96ad48c8-43b0-4459-9cb7-bd8ee24262d2.png">
