### PR TITLE
Make command palette subheaders use eyebrow style

### DIFF
--- a/frontend/src/components/molecules/CommandPalette.tsx
+++ b/frontend/src/components/molecules/CommandPalette.tsx
@@ -49,7 +49,7 @@ const CommandList = styled(Command.List)`
 `
 const CommandGroup = styled(Command.Group)`
     [cmdk-group-heading] {
-        ${Typography.label}
+        ${Typography.eyebrow}
         padding: ${Spacing._8} ${Spacing._16};
         color: ${Colors.text.light};
     }


### PR DESCRIPTION
<img width="439" alt="Screen Shot 2022-10-12 at 11 33 03 AM" src="https://user-images.githubusercontent.com/31417618/195421081-188158e4-d720-4b89-8325-13e8e12c377d.png">
