### PR TITLE
Fix Slack error when saving message that has new lines

### DIFF
--- a/backend/api/slack_task_create.go
+++ b/backend/api/slack_task_create.go
@@ -172,7 +172,8 @@ func (api *API) SlackTaskCreate(c *gin.Context) {
 			Handle500(c)
 			return
 		}
-		modalMetadata := strings.Replace(string(jsonBytes), "\"", "\\\"", -1)
+		modalMetadata := strings.Replace(string(jsonBytes), `\n`, ``, -1)
+		modalMetadata = strings.Replace(string(modalMetadata), `"`, `\"`, -1)
 
 		title, err := getSlackMessageTitle(source, slackParams, externalToken)
 		if err != nil {


### PR DESCRIPTION
Noticed this bug recently.