### PR TITLE
Make focus mode random task button only span text

### DIFF
--- a/frontend/src/components/focus-mode/FlexTime.tsx
+++ b/frontend/src/components/focus-mode/FlexTime.tsx
@@ -55,6 +55,7 @@ const NewTaskRecommendationsButton = styled.div`
     ${Typography.bodySmall};
     cursor: pointer;
     user-select: none;
+    width: fit-content;
 `
 
 const currentFifteenMinuteBlock = (currentTime: DateTime) => {


### PR DESCRIPTION
Previously the random task button spanned the entire container, and not just the text.