### PR TITLE
Less padding for calendar header

### DIFF
--- a/frontend/src/components/calendar/CalendarHeader.tsx
+++ b/frontend/src/components/calendar/CalendarHeader.tsx
@@ -22,7 +22,7 @@ const ConnectContainer = styled.div`
     z-index: 100;
 `
 const PaddedContainer = styled.div`
-    padding: ${Spacing._16} ${Spacing._4} ${Spacing._16} ${Spacing._12};
+    padding: ${Spacing._8} ${Spacing._12};
 `
 const HeaderBodyContainer = styled.div`
     display: flex;


### PR DESCRIPTION
<img width="175" alt="Screen Shot 2022-10-17 at 3 41 12 PM" src="https://user-images.githubusercontent.com/31417618/196297088-5029a386-766b-450f-8b82-0ef30ce93dd7.png">
