### PR TITLE
Handle onMouseUp event for date picker

### DIFF
--- a/frontend/src/components/molecules/GTDatePicker.tsx
+++ b/frontend/src/components/molecules/GTDatePicker.tsx
@@ -104,6 +104,7 @@ const GTDatePicker = ({ initialDate, setDate, showIcon = true, onlyCalendar = fa
                         justifyContent: 'center',
                     },
                 }}
+                renderDay={(date) => <div onMouseUp={() => handleOnChange(date)}>{date.getDate()}</div>}
             />
             {isValidDueDate(value) && (
                 <DateViewContainer>


### PR DESCRIPTION
In the video below, I demonstrate that you don't need to release the right mouse button between right clicking on the task and lifting it while hovered over a date in the date picker.

https://user-images.githubusercontent.com/31417618/196833413-b1f6cce7-2473-4000-a831-90c78017d0cb.mov

