### PR TITLE
Completing the selected task moves the selection to the next available task instead of to the top of the list

### DIFF
--- a/frontend/src/components/views/TaskSectionView.tsx
+++ b/frontend/src/components/views/TaskSectionView.tsx
@@ -75,11 +75,14 @@ const TaskSectionView = () => {
         })
     }, [section, selectedSort, selectedSortDirection, selectedFilter])
 
-    const taskIndex = useMemo(() => {
-        // Find the index of the currently selected task. If the task is not found, return 0
-        const index = sortedTasks.findIndex(({ id }) => id === task?.id)
-        return index === -1 ? 0 : index
-    }, [params.task, params.section])
+    const [taskIndex, setTaskIndex] = useState(0)
+
+    useEffect(() => {
+        if (task) {
+            const index = sortedTasks.findIndex(({ id }) => id === task.id)
+            setTaskIndex(index === -1 ? 0 : index)
+        }
+    }, [params.task, params.section, sortedTasks, task])
 
     const selectTask = useCallback(
         (task: TTask) => {


### PR DESCRIPTION
Only works on task folder pages for now. Looking at options for other pages.

This is the “proper” behavior and then the bug behavior
https://user-images.githubusercontent.com/31417618/197268612-6910d4fc-e9a2-410c-b932-ac8e312e3cc8.mov

