### PR TITLE
Fix optimistic task creation ordering

### DIFF
--- a/frontend/src/services/api/tasks.hooks.ts
+++ b/frontend/src/services/api/tasks.hooks.ts
@@ -120,10 +120,9 @@ export const useCreateTask = () => {
                 const updatedSections = produce(sections, (draft) => {
                     const section = draft.find((section) => section.id === data.taskSectionId)
                     if (!section) return
-                    const orderingId = section.tasks.length > 0 ? section.tasks[0].id_ordering - 1 : 1
                     const newTask: TTask = {
                         id: data.optimisticId,
-                        id_ordering: orderingId,
+                        id_ordering: 0.5,
                         title: data.title,
                         body: data.body ?? '',
                         deeplink: '',
@@ -153,10 +152,9 @@ export const useCreateTask = () => {
                 const updatedViews = produce(views, (draft) => {
                     const section = draft.find((view) => view.task_section_id === data.taskSectionId)
                     if (!section) return
-                    const orderingId = section.view_items.length > 0 ? section.view_items[0].id_ordering - 1 : 1
                     const newTask = {
                         id: data.optimisticId,
-                        id_ordering: orderingId,
+                        id_ordering: 0.5,
                         title: data.title,
                         body: data.body ?? '',
                         deeplink: '',


### PR DESCRIPTION
Gives new tasks an ordering ID of 0.5
- its less than 1 so it gets placed before the first task in the list
- its also not 0, because this is a "falsy/empty" value that gets sorted to the bottom of the list

https://user-images.githubusercontent.com/42781446/197737138-f055919c-9f1d-4e98-9575-6cf8f5f280b4.mov

