### PR TITLE
Make task sorting more stable

### DIFF
--- a/frontend/src/utils/sortAndFilter/sortAndFilterItems.ts
+++ b/frontend/src/utils/sortAndFilter/sortAndFilterItems.ts
@@ -7,7 +7,8 @@ const sortAndFilterItems = <T>({ items, sort, sortDirection, filter, tieBreakerF
             const sortDirectionMultiplier = (sort.forceDirection ?? sortDirection) === SORT_DIRECTION.ASC ? 1 : -1
             let result = 0
             if (a[sort.field] === b[sort.field]) {
-                result = a[tieBreakerField] > b[tieBreakerField] ? -1 : 1
+                result = a[tieBreakerField] < b[tieBreakerField] ? -1 : 1
+                result *= sortDirectionMultiplier
             } else {
                 if (a[sort.field] && b[sort.field]) {
                     if (sort.customComparator) {


### PR DESCRIPTION
See the demo. When tasks do not have a priority (or whatever field we're sorting by), they should stay in the same order at the bottom of the list
Before:

https://user-images.githubusercontent.com/42781446/197740102-b9a1d31b-b6dd-4aac-a487-2769b5b283f6.mov

After:

https://user-images.githubusercontent.com/42781446/197739885-a7be792c-ef2c-4ec9-93cc-0ec173709376.mov

