### PR TITLE
Remove redundant events refetch call

### DIFF
--- a/frontend/src/hooks/useEventBanners.tsx
+++ b/frontend/src/hooks/useEventBanners.tsx
@@ -18,7 +18,7 @@ const isEventWithinTenMinutes = (event: TEvent) => {
 
 export default function useEventBanners(date: DateTime) {
     const [eventsWithinTenMinutes, setEventsWithinTenMinutes] = useState<TEvent[]>([])
-    const { data: events, refetch } = useGetEvents(
+    const { data: events } = useGetEvents(
         {
             startISO: date.startOf('day').toISO(),
             endISO: date.endOf('day').plus({ minutes: 15 }).toISO(),


### PR DESCRIPTION
We do this both here in and with the `refetchInterval` in `events.hooks.ts`, so i removed this one