### PR TITLE
PR details crash fix

### DIFF
--- a/frontend/src/components/details/PullRequestDetails.tsx
+++ b/frontend/src/components/details/PullRequestDetails.tsx
@@ -118,6 +118,7 @@ const PullRequestDetails = ({ pullRequest }: PullRequestDetailsProps) => {
                     <Divider color={Colors.border.extra_light} />
                     <Eyebrow color="light">{`Comments (${num_comments})`}</Eyebrow>
                     {comments
+                        .slice()
                         .sort((a, b) => +DateTime.fromISO(a.last_updated_at) - +DateTime.fromISO(b.last_updated_at))
                         .map((c) => (
                             <PullRequestComment


### PR DESCRIPTION
Issue happened because .sort() mutates arrays in place and the array is part of an immutable query response. This change makes a copy of the array before we sort it so that we have no such issues.

More info: https://stackoverflow.com/questions/49278578/reactjs-sorting-typeerror-0-is-read-only