### PR TITLE
Add PR status tooltip to details

### DIFF
--- a/frontend/src/components/details/PullRequestDetails.tsx
+++ b/frontend/src/components/details/PullRequestDetails.tsx
@@ -5,16 +5,15 @@ import styled from 'styled-components'
 import { useGetPullRequests } from '../../services/api/pull-request.hooks'
 import { Colors, Spacing, Typography } from '../../styles'
 import { icons, logos } from '../../styles/images'
-import { PULL_REQUEST_ACTIONS, colorToIcon } from '../../utils/sortAndFilter/pull-requests.config'
+import { PULL_REQUEST_ACTIONS } from '../../utils/sortAndFilter/pull-requests.config'
 import { TPullRequest } from '../../utils/types'
 import { getHumanTimeSinceDateTime } from '../../utils/utils'
 import { Icon } from '../atoms/Icon'
 import { Divider } from '../atoms/SectionDivider'
-import TooltipWrapper from '../atoms/TooltipWrapper'
 import ExternalLinkButton from '../atoms/buttons/ExternalLinkButton'
 import { Eyebrow, Label } from '../atoms/typography/Typography'
 import BranchName from '../pull-requests/BranchName'
-import { Status } from '../pull-requests/styles'
+import Status from '../pull-requests/Status'
 import DetailsViewTemplate from '../templates/DetailsViewTemplate'
 import PullRequestComment from './pr/PullRequestComment'
 
@@ -104,12 +103,7 @@ const PullRequestDetails = ({ pullRequest }: PullRequestDetailsProps) => {
             </DetailsTopContainer>
             <TitleContainer>{title}</TitleContainer>
             <InfoContainer>
-                <TooltipWrapper dataTip={statusDescription ?? ''} tooltipId="tooltip">
-                    <Status type={status.color}>
-                        <Icon icon={colorToIcon[status.color]} color={status.color} />
-                        {status.text}
-                    </Status>
-                </TooltipWrapper>
+                <Status description={statusDescription} status={status.text} color={status.color} />
                 <Gap4>
                     <LinesModified color="green">{`+${additions}`}</LinesModified>
                     <LinesModified color="red">{`-${deletions}`}</LinesModified>

--- a/frontend/src/components/pull-requests/PullRequest.tsx
+++ b/frontend/src/components/pull-requests/PullRequest.tsx
@@ -1,15 +1,13 @@
-import { useCallback, useEffect } from 'react'
+import { useCallback } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
-import ReactTooltip from 'react-tooltip'
 import Log from '../../services/api/log'
-import { PULL_REQUEST_ACTIONS, colorToIcon } from '../../utils/sortAndFilter/pull-requests.config'
+import { PULL_REQUEST_ACTIONS } from '../../utils/sortAndFilter/pull-requests.config'
 import { TPullRequest } from '../../utils/types'
 import CommentCount from '../atoms/CommentCount'
-import { Icon } from '../atoms/Icon'
 import { PurpleEdge } from '../atoms/SelectableContainer'
-import TooltipWrapper from '../atoms/TooltipWrapper'
 import ExternalLinkButton from '../atoms/buttons/ExternalLinkButton'
-import { Column, LinkButtonContainer, PullRequestRow, Status, TitleContainer } from './styles'
+import Status from './Status'
+import { Column, LinkButtonContainer, PullRequestRow, TitleContainer } from './styles'
 
 interface PullRequestProps {
     pullRequest: TPullRequest
@@ -29,21 +27,12 @@ const PullRequest = ({ pullRequest, link, isSelected }: PullRequestProps) => {
 
     const statusDescription = PULL_REQUEST_ACTIONS.find((action) => action.text === status.text)?.description
 
-    useEffect(() => {
-        ReactTooltip.rebuild()
-    }, [])
-
     return (
         <PullRequestRow onClick={onClickHandler} isSelected={isSelected}>
             {isSelected && <PurpleEdge />}
             <TitleContainer>{title}</TitleContainer>
             <Column>
-                <TooltipWrapper dataTip={statusDescription ?? ''} tooltipId="tooltip">
-                    <Status type={status.color}>
-                        <Icon icon={colorToIcon[status.color]} color={status.color} />
-                        {status.text}
-                    </Status>
-                </TooltipWrapper>
+                <Status description={statusDescription} status={status.text} color={status.color} />
                 {num_comments > 0 && <CommentCount count={num_comments} />}
                 <LinkButtonContainer>
                     <ExternalLinkButton link={deeplink} />

--- a/frontend/src/components/pull-requests/Status.tsx
+++ b/frontend/src/components/pull-requests/Status.tsx
@@ -1,0 +1,44 @@
+import { useEffect } from 'react'
+import ReactTooltip from 'react-tooltip'
+import styled from 'styled-components'
+import { Border, Colors, Spacing, Typography } from '../../styles'
+import { TStatusColors } from '../../styles/colors'
+import { colorToIcon } from '../../utils/sortAndFilter/pull-requests.config'
+import { Icon } from '../atoms/Icon'
+import TooltipWrapper from '../atoms/TooltipWrapper'
+
+const StatusContainer = styled.div<{ type: TStatusColors }>`
+    display: flex;
+    gap: ${Spacing._4};
+    color: ${Colors.text.black};
+    background: ${(props) => Colors.status[props.type].light};
+    border: ${Border.stroke.medium} solid ${(props) => Colors.status[props.type].default};
+    border-radius: ${Border.radius.small};
+    padding: ${Spacing._4} ${Spacing._8};
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    max-width: fit-content;
+    ${Typography.label};
+    ${Typography.bold};
+`
+
+interface StatusProps {
+    description?: string
+    status: string
+    color: TStatusColors
+}
+const Status = ({ description = '', status, color }: StatusProps) => {
+    useEffect(() => {
+        ReactTooltip.rebuild()
+    }, [])
+    return (
+        <TooltipWrapper dataTip={description} tooltipId="tooltip">
+            <StatusContainer type={color}>
+                <Icon icon={colorToIcon[color]} color={color} />
+                {status}
+            </StatusContainer>
+        </TooltipWrapper>
+    )
+}
+
+export default Status


### PR DESCRIPTION
This was left out of the original status tooltip pull request. Not sure why, but it's fixed now.
<img width="689" alt="Screen Shot 2022-10-26 at 10 40 43 AM" src="https://user-images.githubusercontent.com/31417618/198097753-75d5ff39-5c49-49c4-aee4-8e16d34eaa1f.png">
