### PR TITLE
Add commit count to PR details

### DIFF
--- a/frontend/src/components/details/PullRequestDetails.tsx
+++ b/frontend/src/components/details/PullRequestDetails.tsx
@@ -79,6 +79,7 @@ const PullRequestDetails = ({ pullRequest }: PullRequestDetailsProps) => {
         base_branch,
         body,
         num_comments,
+        num_commits,
         comments,
         additions,
         deletions,
@@ -104,7 +105,7 @@ const PullRequestDetails = ({ pullRequest }: PullRequestDetailsProps) => {
                     <LinesModified color="red">{`-${deletions}`}</LinesModified>
                 </Gap4>
             </InfoContainer>
-            <Label color="light">{`#${number} updated ${formattedTimeSince} by ${author}`}</Label>
+            <Label color="light">{`#${number} updated ${formattedTimeSince} by ${author} (${num_commits} commits)`}</Label>
             <BranchInfoContainer>
                 <BranchName name={branch} />
                 <Icon icon={icons.arrow_right} />


### PR DESCRIPTION
Just noticed that the updated_at time doesn't necessarily mean that the author updated it, while the text seems to imply that the author updated it. I don't think this is a huge issue but we might want to reword things in the future if it's confusing to people.

<img width="678" alt="Screen Shot 2022-10-26 at 11 12 25 AM" src="https://user-images.githubusercontent.com/31417618/198103865-c8a6d625-5bfc-4118-83bb-9a6d4dea6dea.png">
