### PR TITLE
[Do Not Land] Mark gcal tokens with bad scopes as bad

### DIFF
--- a/backend/external/gcal.go
+++ b/backend/external/gcal.go
@@ -190,7 +190,8 @@ func (googleCalendar GoogleCalendarSource) DeleteEvent(db *mongo.Database, userI
 
 // returns true if the error was because of a bad token
 func checkAndHandleBadToken(err error, db *mongo.Database, userID primitive.ObjectID, accountID string, serviceID string) bool {
-	if !strings.Contains(err.Error(), "oauth2: token expired and refresh token is not set") {
+	if !strings.Contains(err.Error(), "oauth2: token expired and refresh token is not set") &&
+		!strings.Contains(err.Error(), "Request had insufficient authentication scopes") {
 		return false
 	}
 	token, err := getExternalToken(db, userID, accountID, serviceID)


### PR DESCRIPTION
this is the [error message from sentry](https://sentry.io/organizations/general-task/issues/3576113800/?query=is%3Aunresolved+GoogleCalendarSource&referrer=issue-stream&statsPeriod=14d#exception):
```
googleapi: Error 403: Request had insufficient authentication scopes.\nDetails:\n[\n  {\n    \"@type\": \"type.googleapis.com/google.rpc.ErrorInfo\",\n    \"domain\": \"googleapis.com\",\n    \"metadata\": {\n      \"method\": \"calendar.v3.Events.List\",\n      \"service\": \"calendar-json.googleapis.com\"\n    },\n    \"reason\": \"ACCESS_TOKEN_SCOPE_INSUFFICIENT\"\n  }\n]\n\nMore details:\nReason: insufficientPermissions, Message: Insufficient Permission\n

```