### PR TITLE
Show focus mode button in week view

### DIFF
--- a/frontend/src/components/calendar/CalendarHeader.tsx
+++ b/frontend/src/components/calendar/CalendarHeader.tsx
@@ -75,6 +75,9 @@ export default function CalendarHeader({
         }
     }
     const selectToday = useCallback(() => {
+        if (calendarType === 'day') {
+            setDayViewDate(DateTime.now())
+        }
         setDate(isCalendarExpanded ? DateTime.now().minus({ days: DateTime.now().weekday % 7 }) : DateTime.now())
     }, [setDate, isCalendarExpanded])
 


### PR DESCRIPTION
Shows the focus mode button (instead of the Today button) if the week view is on "this week"

<img width="858" alt="Screen Shot 2022-10-31 at 3 41 11 PM" src="https://user-images.githubusercontent.com/31417618/199123518-660e412f-9885-4b41-9897-67b0b8c8f646.png">
