### PR TITLE
Fix date header bug

### DIFF
--- a/frontend/src/components/views/CalendarView.tsx
+++ b/frontend/src/components/views/CalendarView.tsx
@@ -34,12 +34,13 @@ interface CalendarViewProps {
 const CalendarView = ({
     initialType,
     initialShowMainHeader,
+    initialShowDateHeader,
     isInitiallyCollapsed,
     hideContainerShadow = false,
     hasLeftBorder = false,
 }: CalendarViewProps) => {
     const [showMainHeader, setShowMainHeader] = useState<boolean>(initialShowMainHeader ?? true)
-    const [showDateHeader, setShowDateHeader] = useState<boolean>(initialShowMainHeader ?? true)
+    const [showDateHeader, setShowDateHeader] = useState<boolean>(initialShowDateHeader ?? true)
     const timeoutTimer = useIdleTimer({}) // default timeout is 20 minutes
     const [dayViewDate, setDayViewDate] = useState<DateTime>(DateTime.now())
     const [date, setDate] = useState<DateTime>(DateTime.now())


### PR DESCRIPTION
Typo was causing the date header to be hidden whenever the main header was hidden.