### PR TITLE
Fix duplicate time indicator bug

### DIFF
--- a/frontend/src/components/calendar/CalendarEvents.tsx
+++ b/frontend/src/components/calendar/CalendarEvents.tsx
@@ -182,7 +182,7 @@ const CalendarEvents = ({ date, primaryAccountID }: CalendarEventsProps) => {
         <AllDaysContainer ref={scrollRef}>
             <TimeAndHeaderContainer>
                 <TimeContainer>
-                    {isDateToday(date) && <TimeIndicator ref={timeIndicatorRef} />}
+                    {isDateToday(date) && calendarType === 'day' && <TimeIndicator ref={timeIndicatorRef} />}
                     <CalendarTimeTable />
                 </TimeContainer>
             </TimeAndHeaderContainer>


### PR DESCRIPTION
The time indicator was being shown in the times column in the week view. This seemed to only happen if the current day is a Sunday.
<img width="286" alt="Screen Shot 2022-11-06 at 11 14 15 AM" src="https://user-images.githubusercontent.com/9156543/199761591-22b6d6ab-8f6a-4a87-aaed-ebd116df7121.png">
