### PR TITLE
Remove divider on feedback modal again

### DIFF
--- a/frontend/src/components/mantine/GTModal.tsx
+++ b/frontend/src/components/mantine/GTModal.tsx
@@ -89,7 +89,7 @@ const GTModal = ({ title, tabs, ...baseModalProps }: GTModalProps) => {
                         <Subtitle>{tab.title}</Subtitle>
                         <GTIconButton icon={icons.x} onClick={() => baseModalProps.setIsModalOpen(false)} />
                     </Flex>
-                    <Divider color={Colors.border.light} />
+                    {Array.isArray(tabs) && <Divider color={Colors.border.light} />}
                     {tab.body}
                 </ModalContent>
             </ModalOuter>


### PR DESCRIPTION
this was re-added with a recent refactor of the GTModal component. This PR once again removes it to address the CAYG notes.