### PR TITLE
Fix tooltip bug where it shows a tooltip when you enter the page

### DIFF
--- a/frontend/src/components/templates/DefaultTemplate.tsx
+++ b/frontend/src/components/templates/DefaultTemplate.tsx
@@ -67,7 +67,6 @@ const DefaultTemplate = ({ children }: DefaultTemplateProps) => {
                 delayUpdate={500}
                 className="tooltip"
                 backgroundColor={Colors.background.white}
-                isCapture={true}
                 textColor={Colors.text.black}
             />
             <NavigationView />


### PR DESCRIPTION
This also un-fixes the bug earlier where the tooltip wouldn't disappear instantly when scrolling, but it's a lesser of two evils thing. Still think we should get rid of react-tooltip and replace it with a better library because now there are two issues where fixing one means seeing the other.