### PR TITLE
Make time indicator not block clicking on events

### DIFF
--- a/frontend/src/components/calendar/TimeIndicator.tsx
+++ b/frontend/src/components/calendar/TimeIndicator.tsx
@@ -27,6 +27,7 @@ const TimeIndicatorContainer = styled.div<{ topOffset: number; hideDot: boolean 
         top: -${(DOT_SIZE - INDICATOR_HEIGHT) / 2}px;
         left: 0;
     }`}
+    pointer-events: none;
 `
 interface TimeIndicatorProps {
     hideDot?: boolean


### PR DESCRIPTION
Previously, clicking directly on the time indicator wouldn't actually click the event underneath. This change just means that the time indicator won't respond to pointer events, so you can always click the event underneath.