### PR TITLE
Include .npmrc in .gitignore

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -13,6 +13,7 @@ yarn-error.log
 cypress/videos/
 cypress/screenshots/
 cypress/fixtures/
+.npmrc
 
 # macOS
 .DS_Store


### PR DESCRIPTION
.npmrc is required for fontawesome-pro package installation with npm: https://fontawesome.com/docs/web/setup/packages