### PR TITLE
Calendar week view label change

### DIFF
--- a/frontend/src/components/calendar/CalendarHeader.tsx
+++ b/frontend/src/components/calendar/CalendarHeader.tsx
@@ -147,7 +147,9 @@ export default function CalendarHeader({
             {showDateHeader && (
                 <PaddedContainer>
                     <HeaderBodyContainer>
-                        <CalendarDateText>{`${date.toFormat('ccc, LLL d')}`}</CalendarDateText>
+                        <CalendarDateText>
+                            {calendarType === 'week' ? date.toFormat('LLLL yyyy') : date.toFormat('ccc, LLL d')}
+                        </CalendarDateText>
                         <ButtonContainer>
                             <GTIconButton onClick={selectPrevious} icon={icons.caret_left} />
                             <GTIconButton onClick={selectNext} icon={icons.caret_right} />


### PR DESCRIPTION
Changes to `Month, Year` from `weekday, Month Day`

<img width="294" alt="Screen Shot 2022-11-16 at 1 18 23 PM" src="https://user-images.githubusercontent.com/31417618/202296470-96856022-4850-4d0a-84c6-d0365e5ede1e.png">
