### PR TITLE
Fix height bug for add new subtask

### DIFF
--- a/frontend/src/components/molecules/subtasks/SubtaskList.tsx
+++ b/frontend/src/components/molecules/subtasks/SubtaskList.tsx
@@ -18,6 +18,7 @@ const AddTaskbutton = styled.div`
     cursor: pointer;
     user-select: none;
     padding: ${Spacing._8};
+    height: fit-content;
     width: fit-content;
     border: ${Border.stroke.small} solid transparent;
     :hover {


### PR DESCRIPTION
Previously the height of the new subtask field was too large because of a flexbox issue
<img width="727" alt="Screen Shot 2022-11-16 at 5 33 20 PM" src="https://user-images.githubusercontent.com/9156543/202309015-9181479f-7e88-449e-be07-0ad90adc8248.png">
