### PR TITLE
Switch placement of optimistic subtask

### DIFF
--- a/frontend/src/services/api/tasks.hooks.ts
+++ b/frontend/src/services/api/tasks.hooks.ts
@@ -141,7 +141,7 @@ const updateCacheForOptimsticSubtask = (queryClient: GTQueryClient, data: TCreat
         }
         if (!parentTask) return
         if (!parentTask.sub_tasks) parentTask.sub_tasks = []
-        parentTask.sub_tasks.push(newSubtask)
+        parentTask.sub_tasks = [newSubtask, ...parentTask.sub_tasks]
     })
     queryClient.setQueryData('tasks', updatedSections)
 }


### PR DESCRIPTION
Previously new subtasks were put at the bottom of the list. Now they are first in the list when created