### PR TITLE
Fix 'meeting is now' bug for done tasks

### DIFF
--- a/frontend/src/components/details/TaskDetails.tsx
+++ b/frontend/src/components/details/TaskDetails.tsx
@@ -125,14 +125,17 @@ const TaskDetails = ({ task, subtask, link }: TaskDetailsProps) => {
 
     useInterval(() => {
         if (!currentTask.meeting_preparation_params) return
-        const minutes = Math.ceil(dateTimeStart.diffNow('minutes').minutes)
-        if (minutes < 0) {
+        const minutesToStart = Math.ceil(dateTimeStart.diffNow('minutes').minutes)
+        const minutesToEnd = Math.ceil(dateTimeEnd.diffNow('minutes').minutes)
+        if (minutesToStart < 0 && minutesToEnd > 0) {
             setMeetingStartText('Meeting is now')
-        } else if (minutes <= 30) {
-            const minutesText = minutes === 1 ? 'minute' : 'minutes'
-            setMeetingStartText(`Starts in ${minutes} ${minutesText}`)
+        } else if (minutesToStart < 0 && minutesToEnd < 0) {
+            setMeetingStartText(null)
+        } else if (minutesToStart <= 30) {
+            const minutesToStartText = minutesToStart === 1 ? 'minute' : 'minutes'
+            setMeetingStartText(`Starts in ${minutesToStart} ${minutesToStartText}`)
         } else {
-            setMeetingStartText('')
+            setMeetingStartText(null)
         }
     }, SINGLE_SECOND_INTERVAL)
 

--- a/frontend/src/components/molecules/Task.tsx
+++ b/frontend/src/components/molecules/Task.tsx
@@ -89,16 +89,21 @@ const Task = ({
     const [isMeetingTextColored, setIsMeetingTextColor] = useState<boolean>(false)
     const { meeting_preparation_params } = task
     const dateTimeStart = DateTime.fromISO(task.meeting_preparation_params?.datetime_start || '')
+    const dateTimeEnd = DateTime.fromISO(meeting_preparation_params?.datetime_end || '')
 
     useInterval(() => {
         if (!meeting_preparation_params) return
-        const minutes = Math.ceil(dateTimeStart.diffNow('minutes').minutes)
-        if (minutes < 0) {
+        const minutesToStart = Math.ceil(dateTimeStart.diffNow('minutes').minutes)
+        const minutesToEnd = Math.ceil(dateTimeEnd.diffNow('minutes').minutes)
+
+        if (minutesToStart < 0 && minutesToEnd > 0) {
             setMeetingStartText('Meeting is now')
             setIsMeetingTextColor(true)
-        } else if (minutes <= 30) {
-            const minutesText = minutes === 1 ? 'minute' : 'minutes'
-            setMeetingStartText(`Starts in ${minutes} ${minutesText}`)
+        } else if (minutesToStart < 0 && minutesToEnd < 0) {
+            setMeetingStartText(null)
+        } else if (minutesToStart <= 30) {
+            const minutesToStartText = minutesToStart === 1 ? 'minute' : 'minutes'
+            setMeetingStartText(`Starts in ${minutesToStart} ${minutesToStartText}`)
             setIsMeetingTextColor(true)
         } else {
             setMeetingStartText(dateTimeStart.toLocaleString(DateTime.TIME_SIMPLE))


### PR DESCRIPTION
Made sure to still show "Meeting is now" if a meeting that is _actually_ now has been marked done

https://user-images.githubusercontent.com/42781446/202548473-d2ef9a15-1897-4f5d-9dac-40a922f24ebe.mov

closes FRO-741