### PR TITLE
Revert meeting prep tasks show up on the calendar

### DIFF
--- a/frontend/src/components/calendar/TasksDue.tsx
+++ b/frontend/src/components/calendar/TasksDue.tsx
@@ -2,10 +2,8 @@ import { useMemo } from 'react'
 import { useLocation } from 'react-router-dom'
 import { DateTime } from 'luxon'
 import styled from 'styled-components'
-import { useGetOverviewViews } from '../../services/api/overview.hooks'
 import { useGetTasks } from '../../services/api/tasks.hooks'
 import { Border, Colors, Spacing } from '../../styles'
-import { TTask } from '../../utils/types'
 import { useCalendarContext } from './CalendarContext'
 import TaskDueBody from './TaskDueBody'
 import TasksDueHeader from './TasksDueHeader'
@@ -29,11 +27,8 @@ const TasksDue = ({ date }: TasksDueProps) => {
     const location = useLocation()
     const isOnFocusMode = location.pathname.includes('focus-mode')
     const { data: taskFolders } = useGetTasks()
-    const { data: lists } = useGetOverviewViews()
     const tasksDueToday = useMemo(() => {
-        const meetingPrepTasks =
-            (lists?.find((list) => list.type === 'meeting_preparation')?.view_items as TTask[]) || []
-        const allTasks = taskFolders?.flatMap((section) => section.tasks).concat(meetingPrepTasks) ?? []
+        const allTasks = taskFolders?.flatMap((section) => section.tasks) ?? []
         const incompleteTasks = allTasks.filter((task) => !task.is_done && !task.is_deleted)
         return incompleteTasks.filter(
             (task) =>
@@ -41,7 +36,7 @@ const TasksDue = ({ date }: TasksDueProps) => {
                 (task.meeting_preparation_params &&
                     DateTime.fromISO(task.meeting_preparation_params.datetime_start).hasSame(date, 'day'))
         )
-    }, [taskFolders, lists, date])
+    }, [taskFolders, date])
     const tasksOverdue = useMemo(() => {
         const allTasks = taskFolders?.flatMap((section) => section.tasks) ?? []
         const incompleteTasks = allTasks.filter((task) => !task.is_done)

--- a/frontend/src/hooks/useNavigateToTask.ts
+++ b/frontend/src/hooks/useNavigateToTask.ts
@@ -56,22 +56,6 @@ const useNavigateToTask = () => {
                     }
                 }
             }
-            // If the task doesn't exist in task sections (ex. Meeting Prep Tasks), force going to the overview page
-            for (const view of views) {
-                for (const item of view.view_items) {
-                    if (item.id === taskID) {
-                        setCalendarType('day')
-                        if (subtaskId) {
-                            navigate(`/overview/${view.id}/${item.id}/${subtaskId}`)
-                            Log(`task_navigate__/overview/${view.id}/${item.id}/${subtaskId}`)
-                        } else {
-                            navigate(`/overview/${view.id}/${item.id}`)
-                            Log(`task_navigate__/overview/${view.id}/${item.id}`)
-                        }
-                        return
-                    }
-                }
-            }
             return isUserOnOverviewPage
         },
         []


### PR DESCRIPTION
No more meeting prep tasks in the "Tasks Due" section of the calendar. This was mistakenly prioritized, when it's a feature we didn't actually want to have.