### PR TITLE
[CAYG] Change today button and shortcut to be "Jump to Today"

### DIFF
--- a/frontend/src/components/calendar/CalendarHeader.tsx
+++ b/frontend/src/components/calendar/CalendarHeader.tsx
@@ -99,7 +99,7 @@ export default function CalendarHeader({
             return date.minus({ days: isCalendarExpanded ? 7 : 1 })
         })
     }, [date, setDate, setDayViewDate, dayViewDate, isCalendarExpanded])
-    useKeyboardShortcut('today', selectToday, isFocusMode)
+    useKeyboardShortcut('jumpToToday', selectToday, isFocusMode)
     useKeyboardShortcut('nextDate', selectNext, isFocusMode)
     useKeyboardShortcut('previousDate', selectPrevious, isFocusMode)
 
@@ -132,7 +132,12 @@ export default function CalendarHeader({
                                     />
                                 </NoStyleLink>
                             ) : (
-                                <GTButton value="Today" onClick={selectToday} size="small" styleType="secondary" />
+                                <GTButton
+                                    value="Jump to Today"
+                                    onClick={selectToday}
+                                    size="small"
+                                    styleType="secondary"
+                                />
                             )}
                             <HeaderIconsContainer>
                                 <GTIconButton

--- a/frontend/src/constants/shortcuts.ts
+++ b/frontend/src/constants/shortcuts.ts
@@ -88,8 +88,8 @@ const KEYBOARD_SHORTCUTS = asShortcuts({
         category: 'Calendar',
         icon: 'caret_left',
     },
-    today: {
-        label: 'Today',
+    jumpToToday: {
+        label: 'Jump to Today',
         key: 't',
         keyLabel: 'T',
         category: 'Calendar',


### PR DESCRIPTION
<img width="257" alt="Screen Shot 2022-11-18 at 4 23 30 PM" src="https://user-images.githubusercontent.com/31417618/202823933-a4324426-df87-4746-b39c-bd8c83e42e76.png">
<img width="411" alt="Screen Shot 2022-11-18 at 4 23 40 PM" src="https://user-images.githubusercontent.com/31417618/202823944-f94f5513-6fb1-48bc-bbc4-83f942db9ef1.png">
