### PR TITLE
Fix long subtask title bug

### DIFF
--- a/frontend/src/components/molecules/subtasks/Subtask.tsx
+++ b/frontend/src/components/molecules/subtasks/Subtask.tsx
@@ -28,6 +28,12 @@ export const SubtaskContainer = styled.div`
     width: 100%;
     box-sizing: border-box;
 `
+const TitleSpan = styled.span`
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+`
 
 interface SubtaskProps {
     parentTaskId: string
@@ -64,7 +70,7 @@ const Subtask = ({ parentTaskId, subtask }: SubtaskProps) => {
                     subtaskId={subtask.id}
                     isSelected={false}
                 />
-                {subtask.title}
+                <TitleSpan>{subtask.title}</TitleSpan>
             </SubtaskContainer>
         </SubtaskDropOffset>
     )


### PR DESCRIPTION
Previously text would overflow outside the subtask container
<img width="612" alt="Screen Shot 2022-11-18 at 7 12 32 PM" src="https://user-images.githubusercontent.com/9156543/202831541-7791c882-8adc-4050-a660-a18c443289fd.png">
