### PR TITLE
Stop refetching tasks endpoint after creating task

### DIFF
--- a/frontend/src/services/api/tasks.hooks.ts
+++ b/frontend/src/services/api/tasks.hooks.ts
@@ -284,8 +284,6 @@ export const createTask = async (data: TCreateTaskData) => {
             id_task_section: data.taskSectionId,
             parent_task_id: data.parent_task_id,
         })
-        // temporary fix to ensure that tasks are ordered correctly when created
-        await apiClient.get('/tasks/v3/')
         return castImmutable(res.data)
     } catch {
         throw new Error('createTask failed')


### PR DESCRIPTION
john fixed this issue so we no longer need this hack