### PR TITLE
Enable searching for command categories

### DIFF
--- a/frontend/src/components/molecules/CommandPalette.tsx
+++ b/frontend/src/components/molecules/CommandPalette.tsx
@@ -178,7 +178,7 @@ const CommandPalette = ({ hideButton }: CommandPaletteProps) => {
                                                 setShowCommandPalette(false)
                                                 action()
                                             }}
-                                            value={label}
+                                            value={`${label} ${category}`}
                                         >
                                             <Flex flex="1" alignItems="center">
                                                 <IconContainer>{icon && <Icon icon={icons[icon]} />}</IconContainer>


### PR DESCRIPTION
Searching for "navigation" will now show all the navigation shortcuts as well as anything matching navigation specifically. (eg. if you have a task named navigation)