### PR TITLE
Set limit for Done section tooltip in collapsed navigation view

### DIFF
--- a/frontend/src/components/navigation_sidebar/NavigationLink.tsx
+++ b/frontend/src/components/navigation_sidebar/NavigationLink.tsx
@@ -149,7 +149,8 @@ const NavigationLink = ({
     }, [needsRelinking])
 
     if (isCollapsed && icon) {
-        const dataTip = taskSection ? `${title} (${count ?? 0})` : title
+        const countOverflow = countWithOverflow(count ?? 0)
+        const dataTip = taskSection ? `${title} (${countOverflow})` : title
         return (
             <TooltipWrapper dataTip={dataTip} tooltipId="navigation-tooltip">
                 <GTIconButton


### PR DESCRIPTION
When a user has more than 99 Done tasks, the tooltip will now show "99+" instead of "100"