### PR TITLE
Delay refetch after queued mutations

### DIFF
--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -21,6 +21,7 @@ export const FIVE_SECOND_TIMEOUT = 5 * 1000
 export const SINGLE_SECOND_INTERVAL = 1000
 export const EVENT_UNDO_TIMEOUT = 5 * 1000
 export const DRAG_TASK_TO_OPEN_CALENDAR_TIMEOUT = 0.5 * 1000
+export const QUEUED_MUTATION_DEBOUNCE = 1 * 1000
 
 // Backend Endpoints
 export const TASKS_URL = REACT_APP_API_BASE_URL + '/tasks/'


### PR DESCRIPTION
This changes introduces a debounce period after mutation requests are sent. This is done by waiting for 1 second, then checking if this request was the last request sent in the past second. 

This should fix the bug john posted here 🤞 https://generaltask.slack.com/archives/C032FP8NXS6/p1669225447131539

For example if we send
-> mutation
-> mutation
[pause for 0.5 seconds]
-> mutation
[we'll only send the `GET /tasks` request again 1 second after the last request has finished]


https://user-images.githubusercontent.com/42781446/203641377-816a4ab2-a319-429b-8697-bddb1660c994.mov

