### PR TITLE
[CAYG] Event Detail Popover styling changes

### DIFF
--- a/frontend/src/components/molecules/EventDetailPopover-styles.tsx
+++ b/frontend/src/components/molecules/EventDetailPopover-styles.tsx
@@ -4,6 +4,7 @@ import NoStyleAnchor from '../atoms/NoStyleAnchor'
 import NoStyleButton from '../atoms/buttons/NoStyleButton'
 
 const MAX_POPUP_LENGTH = 315
+const MAX_POPUP_HEIGHT = 500
 
 export const EventBoxStyle = styled.div`
     box-sizing: border-box;
@@ -52,6 +53,7 @@ export const Description = styled.div`
     color: ${Colors.text.black};
     overflow-wrap: break-word;
     overflow-y: auto;
+    max-height: ${MAX_POPUP_HEIGHT}px;
     margin-bottom: ${Spacing._16};
 `
 export const FlexAnchor = styled(NoStyleAnchor)`


### PR DESCRIPTION
- Event description grows MUCH taller before scrolling
- More spacing at the bottom of the description

<img width="608" alt="Screen Shot 2022-11-23 at 2 44 25 PM" src="https://user-images.githubusercontent.com/31417618/203651156-280ced1f-08b3-465e-b1ea-4f0af86457e1.png">
