### PR TITLE
[CAYG] Fallback to old purple

### DIFF
--- a/frontend/src/styles/colors.ts
+++ b/frontend/src/styles/colors.ts
@@ -27,7 +27,7 @@ const BLUE = {
     _2: '#BEEBFF',
 }
 const PURPLE = {
-    _1: '#523178',
+    _1: '#5634CF',
     _2: '#EEEBFA',
     _3: '#E1D7FD33', // NOT IN DESIGN DOC (only used for drop indicator)
 }


### PR DESCRIPTION
Primarily to get a hoverstate back on buttons, but the new purple is just too dark. We will change this eventually when we get more design input on the color scheme.