### PR TITLE
Add task v4 endpoint

### DIFF
--- a/frontend/src/services/api/tasksv4.hooks.ts
+++ b/frontend/src/services/api/tasksv4.hooks.ts
@@ -1,0 +1,16 @@
+import { QueryFunctionContext, useQuery } from 'react-query'
+import { castImmutable } from 'immer'
+import apiClient from '../../utils/api'
+import { TTaskV4 } from '../../utils/types'
+
+export const useGetTasksV4 = (isEnabled = true) => {
+    return useQuery<TTaskV4[], void>('tasks_v4', getTasksV4, { enabled: isEnabled, refetchOnMount: false })
+}
+const getTasksV4 = async ({ signal }: QueryFunctionContext) => {
+    try {
+        const res = await apiClient.get('/tasks/v4/', { signal })
+        return castImmutable(res.data)
+    } catch {
+        throw new Error('getTasks failed')
+    }
+}

--- a/frontend/src/utils/types.ts
+++ b/frontend/src/utils/types.ts
@@ -51,6 +51,31 @@ export interface TTask {
     updated_at: string
     parentTaskId?: string
 }
+export interface TTaskV4 {
+    id: string
+    id_ordering: number
+    title: string
+    deeplink: string
+    body: string
+    priority_normalized: number
+    due_date: string
+    source: TTaskSource
+    is_done: boolean
+    is_deleted: boolean
+    created_at: string
+    updated_at: string
+    id_folder: string
+    id_nux_number?: number
+    id_parent?: string
+    subtask_ids?: string[]
+    meeting_preparation_params?: TMeetingPreparationParams
+    slack_message_params?: TSlackMessageParams
+    comments?: TLinearComment[]
+    external_status?: TExternalStatus
+
+    optimisticId?: string // Used only internally, not sent in response
+    all_statuses?: TExternalStatus[] // Deprecated but still in response (will be moved to userInfo)
+}
 
 export interface TMeetingPreparationParams {
     datetime_start: string


### PR DESCRIPTION
Creating a new file for task v4 endpoints. This will be merged with the `tasks.hooks.ts` eventually, but for now, I'm trying to keep things relatively separate so that we can still work on other parts of the codebase without issues.

The task v4 endpoint is a flat map of all the tasks, instead of subtasks inside of tasks inside of task folders like little russian nesting dolls
