### PR TITLE
Switch radix components to use transient props

### DIFF
--- a/frontend/src/components/radix/GTContextMenu.tsx
+++ b/frontend/src/components/radix/GTContextMenu.tsx
@@ -1,7 +1,6 @@
 import { Fragment } from 'react'
 import * as ContextMenu from '@radix-ui/react-context-menu'
 import styled from 'styled-components'
-import { TTextColor } from '../../styles/colors'
 import { icons } from '../../styles/images'
 import { stopKeydownPropogation } from '../../utils/utils'
 import { Icon } from '../atoms/Icon'
@@ -23,10 +22,10 @@ const ContextMenuContent = styled(ContextMenu.Content)`
 const ContextMenuSubContent = styled(ContextMenu.SubContent)`
     ${MenuContentShared};
 `
-const ContextMenuItem = styled(ContextMenu.Item)<{ textcolor?: TTextColor }>`
+const ContextMenuItem = styled(ContextMenu.Item)`
     ${MenuItemShared};
 `
-const ContextMenuSubTrigger = styled(ContextMenu.SubTrigger)<{ textcolor?: TTextColor }>`
+const ContextMenuSubTrigger = styled(ContextMenu.SubTrigger)`
     ${MenuItemShared};
 `
 const FullWidth = styled.div`
@@ -52,7 +51,7 @@ const GTContextMenu = ({ items, trigger, onOpenChange }: GTContextMenuProps) => 
                                         <ContextMenuSubTrigger
                                             key={item.label}
                                             onClick={item.onClick}
-                                            textcolor={item.textColor}
+                                            $textColor={item.textColor}
                                         >
                                             {item.icon && <Icon icon={item.icon} color={item.iconColor} />}
                                             <MenuItemLabel>{item.label}</MenuItemLabel>
@@ -89,7 +88,7 @@ const GTContextMenu = ({ items, trigger, onOpenChange }: GTContextMenuProps) => 
                                         key={item.label}
                                         textValue={item.label}
                                         onClick={item.onClick}
-                                        textcolor={item.textColor}
+                                        $textColor={item.textColor}
                                     >
                                         {item.icon && <Icon icon={item.icon} color={item.iconColor} />}
                                         {item.label}

--- a/frontend/src/components/radix/GTDropdownMenu.tsx
+++ b/frontend/src/components/radix/GTDropdownMenu.tsx
@@ -2,7 +2,6 @@ import { Fragment, useRef } from 'react'
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
 import styled from 'styled-components'
 import { Colors } from '../../styles'
-import { TTextColor } from '../../styles/colors'
 import { icons } from '../../styles/images'
 import { emptyFunction, stopKeydownPropogation } from '../../utils/utils'
 import { Icon } from '../atoms/Icon'
@@ -19,16 +18,13 @@ import {
 const DropdownMenuTrigger = styled(DropdownMenu.Trigger)`
     ${MenuTriggerShared};
 `
-const DropdownMenuContent = styled(DropdownMenu.Content)<{ menuInModal?: boolean; width?: number }>`
+const DropdownMenuContent = styled(DropdownMenu.Content)<{ $menuInModal?: boolean; $width?: number }>`
     ${MenuContentShared};
-    ${({ menuInModal }) => menuInModal && `z-index: 1000;`}
-    ${({ width }) => width && `width: ${width}px;`}
+    ${({ $menuInModal }) => $menuInModal && `z-index: 1000;`}
+    ${({ $width }) => $width && `width: ${$width}px;`}
     box-sizing: border-box;
 `
-const DropdownMenuItem = styled(DropdownMenu.Item)<{
-    textcolor?: TTextColor
-    disabled?: boolean
-}>`
+const DropdownMenuItem = styled(DropdownMenu.Item)`
     ${MenuItemShared};
     width: 100%;
     box-sizing: border-box;
@@ -72,8 +68,8 @@ const GTDropdownMenu = ({
                     <DropdownMenuContent
                         onKeyDown={(e) => stopKeydownPropogation(e, ['Escape'], true)}
                         align={align}
-                        menuInModal={menuInModal}
-                        width={useTriggerWidth ? triggerRef.current?.getBoundingClientRect().width : undefined}
+                        $menuInModal={menuInModal}
+                        $width={useTriggerWidth ? triggerRef.current?.getBoundingClientRect().width : undefined}
                     >
                         {groups.map((group, groupIndex) => (
                             <Fragment key={groupIndex}>
@@ -84,7 +80,7 @@ const GTDropdownMenu = ({
                                             textValue={item.label}
                                             onClick={item.disabled ? emptyFunction : item.onClick}
                                             disabled={item.disabled}
-                                            textcolor={item.textColor}
+                                            $textColor={item.textColor}
                                         >
                                             {item.renderer ? (
                                                 item.renderer()

--- a/frontend/src/components/radix/GTPopover.tsx
+++ b/frontend/src/components/radix/GTPopover.tsx
@@ -34,7 +34,7 @@ const GTPopover = ({
 }: GTPopoverProps) => {
     return (
         <Popover.Root modal={modal} open={isOpen} onOpenChange={setIsOpen}>
-            <PopoverTrigger disabled={disabled} unstyled={unstyledTrigger}>
+            <PopoverTrigger disabled={disabled} $unstyled={unstyledTrigger}>
                 {trigger}
             </PopoverTrigger>
             {content && (

--- a/frontend/src/components/radix/RadixUIConstants.ts
+++ b/frontend/src/components/radix/RadixUIConstants.ts
@@ -5,12 +5,12 @@ import { TIconType } from '../atoms/Icon'
 
 const MENU_WIDTH = '192px'
 
-export const MenuTriggerShared = css<{ unstyled?: boolean }>`
+export const MenuTriggerShared = css<{ $unstyled?: boolean }>`
     all: unset;
     width: 100%;
     height: 100%;
-    ${({ unstyled }) =>
-        !unstyled &&
+    ${({ $unstyled }) =>
+        !$unstyled &&
         `
         border-radius: ${Border.radius.small};
         &:focus {
@@ -18,7 +18,7 @@ export const MenuTriggerShared = css<{ unstyled?: boolean }>`
         }
     `}
 `
-export const MenuItemShared = css<{ textcolor?: TTextColor; disabled?: boolean }>`
+export const MenuItemShared = css<{ $textColor?: TTextColor; $disabled?: boolean }>`
     display: flex;
     align-items: center;
     gap: ${Spacing._12};
@@ -28,9 +28,9 @@ export const MenuItemShared = css<{ textcolor?: TTextColor; disabled?: boolean }
     padding: ${Spacing._4} ${Spacing._12};
     outline: none;
     border-radius: ${Border.radius.mini};
-    ${({ textcolor }) => textcolor && `color: ${Colors.text[textcolor]};`}
-    ${({ disabled }) =>
-        !disabled &&
+    ${({ $textColor }) => $textColor && `color: ${Colors.text[$textColor]};`}
+    ${({ $disabled }) =>
+        !$disabled &&
         `:hover, :focus {
         outline: ${Border.stroke.small} solid ${Colors.border.light};
         background-color: ${Colors.background.medium};


### PR DESCRIPTION
This avoids issues where the props were being added to the DOM by radix and throwing errors. They're more annoying than anything else, but this is the way we should be doing it.