### PR TITLE
Event banners performance improvements

### DIFF
--- a/frontend/src/hooks/useEventBanners.tsx
+++ b/frontend/src/hooks/useEventBanners.tsx
@@ -94,6 +94,6 @@ export default function useEventBanners(date: DateTime) {
             if (currentMeeting?.conference_call.url) {
                 window.open(currentMeeting.conference_call.url, '_blank')
             }
-        }, [eventsWithinTenMinutes.current])
+        }, [])
     )
 }


### PR DESCRIPTION
the `useEventBanners` hook was continuously causing `MainScreen` to re-render. This change moves the state/global var to refs since no components depend on this state to render.

Everything still seems to work as intended

<img width="1342" alt="image" src="https://user-images.githubusercontent.com/42781446/205472897-283ba2e3-2776-4289-b8b1-be9d773172a4.png">
