### PR TITLE
Submit recurring task form with Enter

### DIFF
--- a/frontend/src/components/molecules/recurring-tasks/RecurringTaskTemplateModal/RecurringTaskTemplateModal.tsx
+++ b/frontend/src/components/molecules/recurring-tasks/RecurringTaskTemplateModal/RecurringTaskTemplateModal.tsx
@@ -93,6 +93,13 @@ const RecurringTaskTemplateModal = ({
         onClose()
     }
 
+    const handleKeyDown = (e: React.KeyboardEvent) => {
+        if (e.key === 'Enter') {
+            handleSave()
+        }
+        stopKeydownPropogation(e, undefined, true)
+    }
+
     return (
         <GTModal
             open
@@ -102,7 +109,7 @@ const RecurringTaskTemplateModal = ({
                 title: 'Setting a recurring task',
                 body: (
                     <>
-                        <Flex flex="1" onKeyDown={(e) => stopKeydownPropogation(e, undefined, true)}>
+                        <Flex flex="1" onKeyDown={handleKeyDown}>
                             <SettingsForm>
                                 {!initialRecurringTaskTemplate && (
                                     <>


### PR DESCRIPTION
Did it manually because keyboard shortcuts behave strangely in modals. Will investigate this more at one point but this should be a fine solution for now since we don't want this to show in the command palette anyways


https://user-images.githubusercontent.com/42781446/205730967-dc314e93-ab3b-4658-9346-d7b201f6e65c.mov

