### PR TITLE
Strongly type task source names

### DIFF
--- a/frontend/src/utils/types.ts
+++ b/frontend/src/utils/types.ts
@@ -5,7 +5,7 @@ import { RecurrenceRate } from './enums'
 export type EmptyString = ''
 
 export interface TTaskSource {
-    name: string
+    name: 'General Task' | 'Google Calendar' | 'Git PR' | 'Jira' | 'Linear' | 'Slack'
     logo: string
     logo_v2: TLogoImage
     is_completable: boolean


### PR DESCRIPTION
Using values defined in the backend here: https://github.com/GeneralTask/task-manager/blob/3aa35d5c28e30f4e8efb1d68dcd5133408e3d65d/backend/external/config.go