### PR TITLE
Fix weird popping behavior of events in focus mode

### DIFF
--- a/frontend/src/components/calendar/utils/eventLayout.ts
+++ b/frontend/src/components/calendar/utils/eventLayout.ts
@@ -18,6 +18,7 @@ function eventsDoOverlap(eventA: TEvent, eventB: TEvent): boolean {
  * overlap with event A.
  */
 function findCollisionGroups(events: TEvent[]): TEvent[][] {
+    events.sort((a, b) => a.title.localeCompare(b.title))
     const collisionGroups: TEvent[][] = [[]]
     events.forEach((event) => {
         let placed = false


### PR DESCRIPTION
All this does is sort events by title (something that is set by the frontend and doesn't change when the event comes back from the backend response). This just ensures that the collision group columns are always laid out in the same order.