### PR TITLE
Update recurring task calendar colors

### DIFF
--- a/frontend/src/components/molecules/recurring-tasks/RecurringTaskTemplateModal/DatePicker.tsx
+++ b/frontend/src/components/molecules/recurring-tasks/RecurringTaskTemplateModal/DatePicker.tsx
@@ -49,23 +49,19 @@ const StyledCalendar = styled(Calendar)<{ disabled: boolean }>`
         `}
     }
     [data-selected='true'] {
-        color: ${Colors.text.black};
         background-color: inherit;
     }
     [data-outside='true'] {
         color: ${Colors.text.light};
     }
     .today {
-        color: ${Colors.text.black};
         border-color: ${Colors.gtColor.primary};
     }
     .selected {
-        color: ${Colors.text.black};
         border-color: ${Colors.gtColor.primary};
         background-color: ${Colors.gtColor.secondary};
     }
     .recurring-selection {
-        color: ${Colors.text.black};
         background-color: ${Colors.gtColor.secondary};
     }
 `


### PR DESCRIPTION
some changes:
- Always show today with a border 
- Weekly mode only shows dates _after_ today
- In monthly/yearly mode highlight the selected date in addition to also showing today
- Made weekends black instead of red
- also i see the shift when the weekday mode is selected - will address in a different PR

https://user-images.githubusercontent.com/42781446/206896823-02b2de57-42d6-4218-a4dd-7d0c8a74040b.mov


