### PR TITLE
Update notes dropdown with nits

### DIFF
--- a/frontend/src/components/notes/NoteSharingDropdown.tsx
+++ b/frontend/src/components/notes/NoteSharingDropdown.tsx
@@ -8,11 +8,11 @@ import { icons } from '../../styles/images'
 import { TNote } from '../../utils/types'
 import { getFormattedDuration } from '../../utils/utils'
 import GTButton from '../atoms/buttons/GTButton'
-import { Mini } from '../atoms/typography/Typography'
+import { Label } from '../atoms/typography/Typography'
 import GTDropdownMenu from '../radix/GTDropdownMenu'
 import { GTMenuItem, MENU_WIDTH } from '../radix/RadixUIConstants'
 
-const MiniWrap = styled(Mini)`
+const LabelWrap = styled(Label)`
     width: ${MENU_WIDTH};
 `
 
@@ -68,7 +68,7 @@ const NoteSharingDropdown = ({ note }: NoteSharingDropdownProps) => {
               },
               {
                   icon: icons.link_slashed,
-                  label: 'Disable shared link...',
+                  label: 'Disable shared link',
                   hideCheckmark: true,
                   onClick: unshareNote,
               },
@@ -77,7 +77,7 @@ const NoteSharingDropdown = ({ note }: NoteSharingDropdownProps) => {
                   disabled: true,
                   keepOpenOnSelect: true,
                   renderer: () => (
-                      <MiniWrap>{`This note is currently being shared. The link will expire in ${sharedUntilString}.`}</MiniWrap>
+                      <LabelWrap>{`This note is currently being shared. The link will expire in ${sharedUntilString}.`}</LabelWrap>
                   ),
               },
           ]
@@ -96,10 +96,10 @@ const NoteSharingDropdown = ({ note }: NoteSharingDropdownProps) => {
                   disabled: true,
                   keepOpenOnSelect: true,
                   renderer: () => (
-                      <MiniWrap>
+                      <LabelWrap>
                           This note is currently not being shared. Sharing a note will share your full name to whoever
                           opens the link. Links to shared notes expire after 3 months upon creation.
-                      </MiniWrap>
+                      </LabelWrap>
                   ),
               },
           ]


### PR DESCRIPTION
Removed ellipsis on 'Disable shared link...'

Changed Mini -> Label to make it easier to read the "disclaimer" text

<img width="421" alt="Screen Shot 2022-12-13 at 6 11 17 PM" src="https://user-images.githubusercontent.com/31417618/207488195-7219fb69-8f6e-4a0d-b2da-e197986c56a2.png">
