### PR TITLE
Update shared note expiry date to match dropdown

### DIFF
--- a/frontend/src/components/notes/SharedNoteView.tsx
+++ b/frontend/src/components/notes/SharedNoteView.tsx
@@ -6,7 +6,7 @@ import { AUTHORIZATION_COOKE } from '../../constants'
 import { useGetNote } from '../../services/api/notes.hooks'
 import { Border, Colors, Shadows, Spacing } from '../../styles'
 import { icons, noteBackground } from '../../styles/images'
-import { emptyFunction, getHumanTimeSinceDateTime } from '../../utils/utils'
+import { emptyFunction, getFormattedDuration, getHumanTimeSinceDateTime } from '../../utils/utils'
 import Flex from '../atoms/Flex'
 import GTTextField from '../atoms/GTTextField'
 import { Icon } from '../atoms/Icon'
@@ -107,9 +107,12 @@ const SharedNoteView = () => {
                                     </Flex>
                                     <Flex gap={Spacing._4}>
                                         <Icon color="gray" icon={icons.link} />
-                                        <Label color="light">{`Link expires in ${DateTime.fromISO(note.shared_until)
-                                            .diffNow(['days', 'hours'])
-                                            .toHuman({ maximumFractionDigits: 0 })}`}</Label>
+                                        <Label color="light">{`Link expires in ${getFormattedDuration(
+                                            DateTime.fromISO(note.shared_until).diffNow('milliseconds', {
+                                                conversionAccuracy: 'longterm',
+                                            }),
+                                            2
+                                        )}`}</Label>
                                     </Flex>
                                 </Flex>
                             </>


### PR DESCRIPTION
<img width="225" alt="Screen Shot 2022-12-13 at 6 29 56 PM" src="https://user-images.githubusercontent.com/31417618/207490628-b0c630b5-6c8c-487d-8993-a924a03786eb.png">
