### PR TITLE
Update "expired" shared note messaging

### DIFF
--- a/frontend/src/components/notes/SharedNoteView.tsx
+++ b/frontend/src/components/notes/SharedNoteView.tsx
@@ -115,10 +115,10 @@ const SharedNoteView = () => {
                             </>
                         ) : (
                             <>
-                                <Title>This link has expired.</Title>
+                                <Title>This note is no longer available.</Title>
                                 <Body>
-                                    The link to this shared note has expired. Please reach out to the person who sent
-                                    this shared note for a new link.
+                                    This shared note has expired or is unavailable. Please reach out to the person who
+                                    sent this shared note for a new link.
                                 </Body>
                             </>
                         )}


### PR DESCRIPTION
Now says "This note is no longer available."
<img width="780" alt="Screen Shot 2022-12-14 at 10 39 31 AM" src="https://user-images.githubusercontent.com/31417618/207683246-0fb8d3e4-e5a2-4bb7-9ee5-97f48fd887aa.png">
