### PR TITLE
Update recurring task calendar colors

### DIFF
--- a/frontend/src/components/molecules/recurring-tasks/RecurringTaskTemplateModal/DatePicker.tsx
+++ b/frontend/src/components/molecules/recurring-tasks/RecurringTaskTemplateModal/DatePicker.tsx
@@ -62,6 +62,9 @@ const StyledCalendar = styled(Calendar)<{ disabled: boolean }>`
         border-color: ${Colors.gtColor.primary};
         background-color: ${Colors.gtColor.secondary};
     }
+    .recurring-past {
+        border-color: ${Colors.gtColor.primary};
+    }
     .recurring-selection {
         background-color: ${Colors.gtColor.secondary};
     }
@@ -99,7 +102,7 @@ const DatePicker = ({ date, setDate, recurrenceRate }: DatePickerProps) => {
             (recurrenceRate === RecurrenceRate.MONTHLY || recurrenceRate === RecurrenceRate.YEARLY)
         ) {
             if (day.getTime() < today.getTime()) {
-                return 'recurring-selection'
+                return 'recurring-past'
             }
             return 'selected'
         }


### PR DESCRIPTION
guidelines from hans:

always show today with a purple background and white text

for monthly/yearly mode:

Always show border for selected date

show background for dates after today


https://user-images.githubusercontent.com/42781446/207696349-2781ae09-16d9-4b5f-9ca3-96f3d00a9692.mov

