### PR TITLE
Ignore context for focus mode calendar

### DIFF
--- a/frontend/src/components/calendar/CalendarContext.tsx
+++ b/frontend/src/components/calendar/CalendarContext.tsx
@@ -60,7 +60,36 @@ const CalendarContext = createContext<ContextValues>({
     setShowTaskToCalSidebar: emptyFunction,
 })
 
-export const useCalendarContext = () => {
+const FocusModeContext = createContext<ContextValues>({
+    date: DateTime.now(),
+    dayViewDate: DateTime.now(),
+    calendarType: 'day',
+    showMainHeader: true,
+    showDateHeader: true,
+    isCollapsed: false,
+    isTaskDraggingOverDetailsView: false,
+    selectedEvent: null,
+    isPopoverDisabled: false,
+    isTasksDueViewCollapsed: false,
+    disableSelectEvent: false,
+    isTasksOverdueViewCollapsed: false,
+    showTaskToCalSidebar: false,
+    setDate: emptyFunction,
+    setDayViewDate: emptyFunction,
+    setCalendarType: emptyFunction,
+    setShowMainHeader: emptyFunction,
+    setShowDateHeader: emptyFunction,
+    setIsCollapsed: emptyFunction,
+    setIsTaskDraggingOverDetailsView: emptyFunction,
+    setSelectedEvent: emptyFunction,
+    setIsPopoverDisabled: emptyFunction,
+    setIsTasksDueViewCollapsed: emptyFunction,
+    setIsTasksOverdueViewCollapsed: emptyFunction,
+    setShowTaskToCalSidebar: emptyFunction,
+})
+
+export const useCalendarContext = (ignoreContext?: boolean | undefined) => {
+    if (ignoreContext) return useContext(FocusModeContext)
     return useContext(CalendarContext)
 }
 

--- a/frontend/src/components/screens/FocusModeScreen.tsx
+++ b/frontend/src/components/screens/FocusModeScreen.tsx
@@ -185,7 +185,7 @@ const getEventsCurrentlyHappening = (events: TEvent[]) => {
 
 const FocusModeScreen = () => {
     const { selectedEvent, setSelectedEvent, setIsPopoverDisabled, setIsCollapsed, setCalendarType } =
-        useCalendarContext()
+        useCalendarContext(true)
     useEffect(() => {
         setIsCollapsed(false)
         setCalendarType('day')
@@ -393,6 +393,7 @@ const FocusModeScreen = () => {
                                 initialShowMainHeader={false}
                                 hideContainerShadow
                                 hasLeftBorder
+                                ignoreContext
                             />
                         </CalendarContainer>
                     </MainContainer>

--- a/frontend/src/components/views/CalendarView.tsx
+++ b/frontend/src/components/views/CalendarView.tsx
@@ -32,6 +32,7 @@ interface CalendarViewProps {
     hideContainerShadow?: boolean
     hasLeftBorder?: boolean
     additonalHeaderContent?: React.ReactNode
+    ignoreContext?: boolean
 }
 const CalendarView = ({
     initialType,
@@ -41,12 +42,13 @@ const CalendarView = ({
     hideContainerShadow = false,
     hasLeftBorder = false,
     additonalHeaderContent,
+    ignoreContext = false,
 }: CalendarViewProps) => {
     const [showMainHeader, setShowMainHeader] = useState<boolean>(initialShowMainHeader ?? true)
     const [showDateHeader, setShowDateHeader] = useState<boolean>(initialShowDateHeader ?? true)
     const timeoutTimer = useIdleTimer({}) // default timeout is 20 minutes
     const { date, calendarType, isCollapsed, setDate, setCalendarType, setIsCollapsed, setShowTaskToCalSidebar } =
-        useCalendarContext()
+        useCalendarContext(ignoreContext)
     const monthBlocks = useMemo(() => {
         const blocks = getMonthsAroundDate(date, 1)
         return blocks.map((block) => ({ startISO: block.start.toISO(), endISO: block.end.toISO() }))


### PR DESCRIPTION
This fixes the bug that caused calendar headers to appear in focus mode when multiple GT tabs were open