### PR TITLE
Fix calendar header color bug

### DIFF
--- a/frontend/src/components/calendar/CalendarEvents-styles.tsx
+++ b/frontend/src/components/calendar/CalendarEvents-styles.tsx
@@ -166,7 +166,6 @@ export const CalendarDayHeader = styled.div`
     justify-content: center;
     height: ${CALENDAR_DAY_HEADER_HEIGHT}px;
     position: sticky;
-    background-color: ${Colors.background.medium};
     top: 0;
     z-index: 2;
     margin: 0 auto;
@@ -175,7 +174,7 @@ export const DayHeaderText = styled.div<{ isToday: boolean }>`
     border-radius: 50vh;
     padding: ${Spacing._4} ${Spacing._8};
     color: ${(props) => (props.isToday ? Colors.text.white : Colors.text.black)};
-    background-color: ${(props) => (props.isToday ? Colors.gtColor.primary : Colors.background.medium)};
+    background-color: ${(props) => (props.isToday ? Colors.gtColor.primary : 'transparent')};
     ${Typography.body};
 `
 export const CalendarContainer = styled.div<{ isExpanded: boolean; showShadow: boolean; hasLeftBorder: boolean }>`


### PR DESCRIPTION
Fixes the following bug: 
<img width="1441" alt="Screen Shot 2022-12-16 at 5 03 28 PM" src="https://user-images.githubusercontent.com/9156543/208214991-57cd4a11-8962-4b52-abaf-f92a22831cb5.png">
