### PR TITLE
Optimistically set recurring task template folders to task inbox when folder is deleted

### DIFF
--- a/frontend/src/services/api/task-section.hooks.ts
+++ b/frontend/src/services/api/task-section.hooks.ts
@@ -68,7 +68,7 @@ export const useDeleteTaskSection = () => {
         tag: 'tasks',
         invalidateTagsOnSettled: ['tasks', 'recurring-tasks'],
         onMutate: async ({ id }) => {
-            await queryClient.cancelQueries('tasks')
+            await Promise.all([queryClient.cancelQueries('tasks'), queryClient.cancelQueries('recurring-tasks')])
 
             const sections = queryClient.getImmutableQueryData<TTaskSection[]>('tasks')
             if (!sections) return


### PR DESCRIPTION
When a folder is deleted, set the id_task_section of all recurring task templates of that folder to the Task Inbox

https://user-images.githubusercontent.com/42781446/208369019-d8e1b080-5dd5-4797-942c-3b7caa448535.mov

corresponding backend change: #2570