### PR TITLE
Add a margin to the Select arrow

### DIFF
--- a/frontend/src/components/radix/GTSelect.tsx
+++ b/frontend/src/components/radix/GTSelect.tsx
@@ -47,7 +47,7 @@ const SelectItemTextContent = styled.div`
     overflow: hidden;
 `
 const DownCaret = styled(Icon)`
-    margin-left: ${Spacing._4};
+    margin-left: ${Spacing._8};
 `
 
 interface GTSelectProps {


### PR DESCRIPTION
before:
<img width="451" alt="image" src="https://user-images.githubusercontent.com/42781446/208370458-1df175be-1b72-4cbd-adf7-5489ee2afdbd.png">

after:
<img width="518" alt="image" src="https://user-images.githubusercontent.com/42781446/208371672-f5ffbdd8-c1d2-4821-8fae-89c547a0afa5.png">

