### PR TITLE
Add replace_existing field to recurring task templates

### DIFF
--- a/backend/api/recurring_task_template_create.go
+++ b/backend/api/recurring_task_template_create.go
@@ -17,6 +17,7 @@ type RecurringTaskTemplateCreateParams struct {
 	TimeOfDaySecondsToCreateTask *int     `json:"time_of_day_seconds_to_create_task,omitempty" binding:"required"`
 	DayToCreateTask              *int     `json:"day_to_create_task,omitempty"`
 	MonthToCreateTask            *int     `json:"month_to_create_task,omitempty"`
+	ReplaceExisting              *bool    `json:"replace_existing,omitempty"`
 }
 
 func (api *API) RecurringTaskTemplateCreate(c *gin.Context) {
@@ -48,6 +49,7 @@ func (api *API) RecurringTaskTemplateCreate(c *gin.Context) {
 		PriorityNormalized:           templateCreateParams.PriorityNormalized,
 		IsEnabled:                    &enabled,
 		IsDeleted:                    &deleted,
+		ReplaceExisting:              templateCreateParams.ReplaceExisting,
 		RecurrenceRate:               templateCreateParams.RecurrenceRate,
 		TimeOfDaySecondsToCreateTask: templateCreateParams.TimeOfDaySecondsToCreateTask,
 		DayToCreateTask:              templateCreateParams.DayToCreateTask,

--- a/backend/api/recurring_task_template_modify.go
+++ b/backend/api/recurring_task_template_modify.go
@@ -21,6 +21,7 @@ type RecurringTaskTemplateModifyParams struct {
 	MonthToCreateTask            *int     `json:"month_to_create_task,omitempty"`
 	IsEnabled                    *bool    `json:"is_enabled,omitempty"`
 	IsDeleted                    *bool    `json:"is_deleted,omitempty"`
+	ReplaceExisting              *bool    `json:"replace_existing,omitempty"`
 }
 
 func (api *API) RecurringTaskTemplateModify(c *gin.Context) {
@@ -75,6 +76,7 @@ func (api *API) RecurringTaskTemplateModify(c *gin.Context) {
 		DayToCreateTask:              modifyParams.DayToCreateTask,
 		MonthToCreateTask:            modifyParams.MonthToCreateTask,
 		IDTaskSection:                taskSection,
+		ReplaceExisting:              modifyParams.ReplaceExisting,
 		UpdatedAt:                    primitive.NewDateTimeFromTime(api.GetCurrentTime()),
 	}
 

--- a/backend/api/recurring_task_template_modify_test.go
+++ b/backend/api/recurring_task_template_modify_test.go
@@ -86,7 +86,7 @@ func TestRecurringTaskTemplateModify(t *testing.T) {
 		request, _ := http.NewRequest(
 			"PATCH",
 			"/recurring_task_templates/modify/"+templateID.Hex()+"/",
-			bytes.NewBuffer([]byte(`{"title": "new title!"}`)),
+			bytes.NewBuffer([]byte(`{"title": "new title!", "replace_existing": true}`)),
 		)
 		request.Header.Add("Authorization", "Bearer "+authToken)
 		recorder := httptest.NewRecorder()
@@ -97,6 +97,7 @@ func TestRecurringTaskTemplateModify(t *testing.T) {
 		err = database.FindWithCollection(database.GetRecurringTaskTemplateCollection(api.DB), userID, &[]bson.M{{"is_deleted": false}}, &templates, nil)
 		assert.NoError(t, err)
 		assert.Equal(t, "new title!", *(templates[0].Title))
+		assert.True(t, *templates[0].ReplaceExisting)
 		assert.Equal(t, primitive.NewDateTimeFromTime(currentTime), templates[0].UpdatedAt)
 	})
 }

--- a/backend/database/models.go
+++ b/backend/database/models.go
@@ -141,6 +141,8 @@ type RecurringTaskTemplate struct {
 	DayToCreateTask              *int               `bson:"day_to_create_task,omitempty" json:"day_to_create_task,omitempty"`
 	MonthToCreateTask            *int               `bson:"month_to_create_task,omitempty" json:"month_to_create_task,omitempty"`
 	LastBackfillDatetime         primitive.DateTime `bson:"last_backfill_datetime,omitempty" json:"last_backfill_datetime,omitempty"`
+	// existing template tasks replaced by new task
+	ReplaceExisting *bool `bson:"replace_existing,omitempty" json:"replace_existing,omitempty"`
 	// created at
 	CreatedAt primitive.DateTime `bson:"created_at,omitempty" json:"created_at,omitempty"`
 	UpdatedAt primitive.DateTime `bson:"updated_at,omitempty" json:"updated_at,omitempty"`


### PR DESCRIPTION
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/GeneralTask/task-manager/pull/2573).
* __->__ #2573

Add replace_existing field to recurring task templates
Adds option to no longer deal with duplicate tasks.

