### PR TITLE
Fix overdue calendar bug

### DIFF
--- a/frontend/src/components/calendar/TasksDue.tsx
+++ b/frontend/src/components/calendar/TasksDue.tsx
@@ -63,7 +63,8 @@ const TasksDue = ({ date }: TasksDueProps) => {
         () =>
             incompleteTasks.filter(
                 (task) =>
-                    !DateTime.fromISO(task.due_date).hasSame(date, 'day') && DateTime.fromISO(task.due_date) < date
+                    !DateTime.fromISO(task.due_date).hasSame(DateTime.now(), 'day') &&
+                    DateTime.fromISO(task.due_date) < DateTime.now()
             ),
         [incompleteTasks, date]
     )


### PR DESCRIPTION
Previously tasks due in the future were being marked as overdue on all dates past the due date