### PR TITLE
Tooltip center bug on chrome

### DIFF
--- a/frontend/src/components/radix/Tip.tsx
+++ b/frontend/src/components/radix/Tip.tsx
@@ -62,6 +62,7 @@ const TriggerSpan = styled.span<{ fitContent?: boolean }>`
         props.fitContent &&
         css`
             width: fit-content;
+            display: block;
         `}
 `
 


### PR DESCRIPTION
Fixes the following bug:
![image](https://user-images.githubusercontent.com/9156543/208565657-2c39a74f-b737-411c-a632-32567165b501.png)
