### PR TITLE
Read from localstorage only once on mount (except for previewMode)

### DIFF
--- a/frontend/src/hooks/usePreviewMode.ts
+++ b/frontend/src/hooks/usePreviewMode.ts
@@ -10,7 +10,7 @@ interface UsePreviewModeOutput {
 
 function usePreviewMode(defaultValue?: boolean): UsePreviewModeOutput {
     const { data: userInfo } = useGetUserInfo()
-    const [isPreviewMode, setPreviewMode] = useGTLocalStorage<boolean>('previewMode', defaultValue ?? false)
+    const [isPreviewMode, setPreviewMode] = useGTLocalStorage<boolean>('previewMode', defaultValue ?? false, true)
 
     return {
         isPreviewMode: isPreviewMode && (userInfo?.is_employee ?? false),


### PR DESCRIPTION
Added option to keep state in sync, which previewMode needs since we expect multiple `usePreviewMode` hooks to stay in sync

https://user-images.githubusercontent.com/42781446/209228872-a796c54c-04a5-4a53-aecf-a0e015e0015d.mov

closes FRO-1045
