### PR TITLE
Select note immediately

### DIFF
--- a/frontend/src/components/views/NoteListView.tsx
+++ b/frontend/src/components/views/NoteListView.tsx
@@ -52,12 +52,12 @@ const NoteListView = () => {
     const selectedNote = useMemo(() => {
         if (sortedNotes.length === 0) return null
         return sortedNotes.find((note) => note.id === noteId) ?? sortedNotes[0]
-    }, [noteId, notes])
+    }, [noteId, notes, sortedNotes])
 
     useEffect(() => {
         if (selectedNote == null) return
         navigate(`/notes/${selectedNote.id}`, { replace: true })
-    }, [selectedNote])
+    }, [selectedNote, navigate])
 
     const selectNote = useCallback(
         (note: TNote) => {


### PR DESCRIPTION
Previously, if you loaded the notes page directly, it wouldn't autoselect the first note. Now it does, and keeps it's selection.