### PR TITLE
Fix event styling for short events that are very close to each other

### DIFF
--- a/frontend/src/components/calendar/utils/eventLayout.ts
+++ b/frontend/src/components/calendar/utils/eventLayout.ts
@@ -1,10 +1,20 @@
+import { FIFTEEN_MINUTE_INTERVAL } from '../../../constants'
 import { TEvent } from '../../../utils/types'
 
 function eventsDoOverlap(eventA: TEvent, eventB: TEvent): boolean {
     const eventAStart = new Date(eventA.datetime_start)
-    const eventAEnd = new Date(eventA.datetime_end)
     const eventBStart = new Date(eventB.datetime_start)
-    const eventBEnd = new Date(eventB.datetime_end)
+
+    let eventAEnd = new Date(eventA.datetime_end)
+    let eventBEnd = new Date(eventB.datetime_end)
+
+    // if the events are less than 15 minutes, consider duration to be 15 minutes
+    if (eventAEnd.getTime() - eventAStart.getTime() < FIFTEEN_MINUTE_INTERVAL) {
+        eventAEnd = new Date(eventAStart.getTime() + FIFTEEN_MINUTE_INTERVAL)
+    }
+    if (eventBEnd.getTime() - eventBStart.getTime() < FIFTEEN_MINUTE_INTERVAL) {
+        eventBEnd = new Date(eventBStart.getTime() + FIFTEEN_MINUTE_INTERVAL)
+    }
 
     return eventAStart < eventBEnd && eventAEnd > eventBStart
 }

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -11,19 +11,20 @@ export const AUTHORIZATION_COOKE = 'authToken'
 export const MESSAGE_TYPE_DM = 'directmessage'
 
 // Time constants (in milliseconds)
-export const TASK_REFETCH_INTERVAL = 60 * 1000
-export const PR_REFETCH_INTERVAL = 120 * 1000
-export const EVENTS_REFETCH_INTERVAL = 60 * 1000
-export const TIME_INDICATOR_INTERVAL = 6 * 1000
-export const TASK_MARK_AS_DONE_TIMEOUT = 0.25 * 1000
-export const DETAILS_SYNC_TIMEOUT = 1 * 1000
-export const NOTE_SYNC_TIMEOUT = 1 * 1000
-export const FIVE_SECOND_TIMEOUT = 5 * 1000
-export const SINGLE_SECOND_INTERVAL = 1000
-export const EVENT_UNDO_TIMEOUT = 5 * 1000
-export const DRAG_TASK_TO_OPEN_CALENDAR_TIMEOUT = 0.5 * 1000
 export const BACKFILL_RECURRING_TASKS_INTERVAL = 5 * 60 * 1000
+export const DETAILS_SYNC_TIMEOUT = 1 * 1000
+export const DRAG_TASK_TO_OPEN_CALENDAR_TIMEOUT = 0.5 * 1000
+export const EVENT_UNDO_TIMEOUT = 5 * 1000
+export const EVENTS_REFETCH_INTERVAL = 60 * 1000
+export const FIFTEEN_MINUTE_INTERVAL = 15 * 60 * 1000
+export const FIVE_SECOND_TIMEOUT = 5 * 1000
+export const NOTE_SYNC_TIMEOUT = 1 * 1000
+export const PR_REFETCH_INTERVAL = 120 * 1000
 export const QUEUED_MUTATION_DEBOUNCE = 1 * 1000
+export const SINGLE_SECOND_INTERVAL = 1000
+export const TASK_MARK_AS_DONE_TIMEOUT = 0.25 * 1000
+export const TASK_REFETCH_INTERVAL = 60 * 1000
+export const TIME_INDICATOR_INTERVAL = 6 * 1000
 
 // Backend Endpoints
 export const TASKS_URL = REACT_APP_API_BASE_URL + '/tasks/'


### PR DESCRIPTION
When considering if two events collide, treat their duration as `min(actual duration, 15 minutes)`

Before:
![image](https://user-images.githubusercontent.com/42781446/209738164-e77a65a3-e2dd-43a6-b559-5c6927dcd9db.png)

After:
![image](https://user-images.githubusercontent.com/42781446/209738169-07ae9d7e-3a03-426c-b38b-dc3dcc769ee7.png)

(Also alphabetized the time constants)