### PR TITLE
Only show "delete note" button for owner of note

### DIFF
--- a/frontend/src/components/notes/NoteActionsDropdown.tsx
+++ b/frontend/src/components/notes/NoteActionsDropdown.tsx
@@ -7,16 +7,28 @@ import Flex from '../atoms/Flex'
 import GTIconButton from '../atoms/buttons/GTIconButton'
 import { Mini } from '../atoms/typography/Typography'
 import GTDropdownMenu from '../radix/GTDropdownMenu'
+import { GTMenuItem } from '../radix/RadixUIConstants'
 
 interface NoteActionsDropdownProps {
     note: TNote
+    isOwner?: boolean
 }
-const NoteActionsDropdown = ({ note }: NoteActionsDropdownProps) => {
+const NoteActionsDropdown = ({ note, isOwner = true }: NoteActionsDropdownProps) => {
     const [isOpen, setIsOpen] = useState(false)
     const { mutate: modifyNote } = useModifyNote()
 
     const updatedAt = DateTime.fromISO(note.updated_at).toFormat(`MMM d 'at' h:mm a`)
     const createdAt = DateTime.fromISO(note.created_at).toFormat(`MMM d 'at' h:mm a`)
+
+    const ownerItems: GTMenuItem[] = [
+        {
+            label: note.is_deleted ? 'Restore Note' : 'Delete Note',
+            icon: icons.trash,
+            iconColor: 'red',
+            textColor: 'red',
+            onClick: () => modifyNote({ id: note.id, is_deleted: !note.is_deleted }, note.optimisticId),
+        },
+    ]
 
     return (
         <GTDropdownMenu
@@ -24,15 +36,7 @@ const NoteActionsDropdown = ({ note }: NoteActionsDropdownProps) => {
             setIsOpen={setIsOpen}
             hideCheckmark
             items={[
-                [
-                    {
-                        label: note.is_deleted ? 'Restore Note' : 'Delete Note',
-                        icon: icons.trash,
-                        iconColor: 'red',
-                        textColor: 'red',
-                        onClick: () => modifyNote({ id: note.id, is_deleted: !note.is_deleted }, note.optimisticId),
-                    },
-                ],
+                ...(isOwner ? [ownerItems] : []),
                 [
                     {
                         label: 'Info',

--- a/frontend/src/components/notes/SharedNoteView.tsx
+++ b/frontend/src/components/notes/SharedNoteView.tsx
@@ -148,7 +148,7 @@ const SharedNoteView = () => {
                                         disabled
                                         readOnly
                                     />
-                                    {isUserNoteOwner && <NoteActionsDropdown note={note} />}
+                                    <NoteActionsDropdown note={note} isOwner={isUserNoteOwner} />
                                 </Flex>
                                 <GTTextField
                                     type="markdown"


### PR DESCRIPTION
Previous fix made the entire menu inaccessible to non-owners, but non-owners still need to be able to see the created_at and updated_at fields. This change just hides the Delete button if the user is not the owner of the note.

<img width="374" alt="Screenshot 2023-01-03 at 2 20 32 PM" src="https://user-images.githubusercontent.com/31417618/210450858-a0403650-f2af-49f9-856d-36f072697323.png">
