### PR TITLE
Reduce initial load time by lazy loading rich text editors

### DIFF
--- a/frontend/src/components/atoms/GTTextField/GTTextField.tsx
+++ b/frontend/src/components/atoms/GTTextField/GTTextField.tsx
@@ -1,11 +1,13 @@
-import { forwardRef, useRef } from 'react'
+import { Suspense, forwardRef, lazy, useRef } from 'react'
 import styled from 'styled-components'
 import { Border, Colors, Shadows } from '../../../styles'
 import { stopKeydownPropogation } from '../../../utils/utils'
-import AtlassianEditor from './AtlassianEditor'
-import MarkdownEditor from './MarkdownEditor/MarkdownEditor'
+import Spinner from '../Spinner'
 import PlainTextEditor from './PlainTextEditor'
 import { GTTextFieldProps } from './types'
+
+const AtlassianEditor = lazy(() => import('./AtlassianEditor'))
+const MarkdownEditor = lazy(() => import('./MarkdownEditor'))
 
 const PlainTextContainer = styled.div<{ hideUnfocusedOutline?: boolean; disabled?: boolean }>`
     border: ${Border.stroke.medium} solid
@@ -83,7 +85,7 @@ const GTTextField = forwardRef((props: GTTextFieldProps, ref) => {
             minHeight={props.minHeight}
             hideUnfocusedOutline={props.hideUnfocusedOutline}
         >
-            {getEditor()}
+            <Suspense fallback={<Spinner />}>{getEditor()}</Suspense>
         </Container>
     )
 })

--- a/frontend/src/components/atoms/GTTextField/MarkdownEditor/index.ts
+++ b/frontend/src/components/atoms/GTTextField/MarkdownEditor/index.ts
@@ -1,0 +1,1 @@
+export { default } from './MarkdownEditor'


### PR DESCRIPTION
This will reduce the initial load time - especially since the atlassian editor is a thicc boi that most users won't use

as shown in the demo, lazy loading means that the bundle only gets loaded when the component is used, and only needs to be loaded once (so we only see the spinner once per editor type)

https://user-images.githubusercontent.com/42781446/210618880-a4fea423-b965-4b6d-ae71-e3f192f53458.mp4



