### PR TITLE
Fix Time Indicator generating too many classes

### DIFF
--- a/frontend/src/components/calendar/TimeIndicator.tsx
+++ b/frontend/src/components/calendar/TimeIndicator.tsx
@@ -36,26 +36,6 @@ const TimeIndicatorContainer = styled.div.attrs(({ topOffset }: TimeIndicatorCon
     }`}
     pointer-events: none;
 `
-// const TimeIndicatorContainer = styled.div<{ topOffset: number; hideDot: boolean }>`
-//     width: 100%;
-//     background-color: ${Colors.gtColor.orange};
-//     height: ${INDICATOR_HEIGHT}px;
-//     position: absolute;
-//     top: ${(props) => props.topOffset}px;
-//     ${(props) =>
-//         !props.hideDot &&
-//         `::before {
-//         content: '';
-//         position: absolute;
-//         width: ${DOT_SIZE}px;
-//         height: ${DOT_SIZE}px;
-//         border-radius: 50%;
-//         background-color: ${Colors.gtColor.orange};
-//         top: -${(DOT_SIZE - INDICATOR_HEIGHT) / 2}px;
-//         left: 0;
-//     }`}
-//     pointer-events: none;
-// `
 interface TimeIndicatorProps {
     hideDot?: boolean
 }


### PR DESCRIPTION
Finally found a solution to this. Been bothering me for the better part of a year. While this isn't a big performance issue right now, it might be a pattern we want to follow in the future when we're doing styled components for things with rapidly changing props.

