### PR TITLE
Lazy load read-only rich text fields

### DIFF
--- a/frontend/src/components/atoms/GTTextField/GTTextField.tsx
+++ b/frontend/src/components/atoms/GTTextField/GTTextField.tsx
@@ -6,8 +6,6 @@ import Spinner from '../Spinner'
 import PlainTextEditor from './PlainTextEditor'
 import { GTTextFieldProps } from './types'
 
-// import x from 'prosemirror-gapcursor'
-
 const AtlassianEditor = lazy(() => import('./AtlassianEditor'))
 const MarkdownEditor = lazy(() => import('./MarkdownEditor'))
 


### PR DESCRIPTION
Refactored so we don't have this extra return statement

Comments look the same - no borders 

![image](https://user-images.githubusercontent.com/42781446/210908993-7fca4673-cab8-4bbf-91bb-eacce468a32c.png)
