### PR TITLE
Non-fuzzy search

### DIFF
--- a/frontend/src/components/molecules/CommandPalette.tsx
+++ b/frontend/src/components/molecules/CommandPalette.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components'
 import { DEFAULT_SECTION_ID, DONE_SECTION_ID, TRASH_SECTION_ID } from '../../constants'
 import KEYBOARD_SHORTCUTS, { ShortcutCategories } from '../../constants/shortcuts'
 import useShortcutContext from '../../context/ShortcutContext'
-import { useKeyboardShortcut } from '../../hooks'
+import { useKeyboardShortcut, usePreviewMode } from '../../hooks'
 import useNavigateToTask from '../../hooks/useNavigateToTask'
 import Log from '../../services/api/log'
 import { useGetTasks } from '../../services/api/tasks.hooks'
@@ -125,6 +125,7 @@ interface CommandPaletteProps {
     hideButton?: boolean
 }
 const CommandPalette = ({ customButton, hideButton }: CommandPaletteProps) => {
+    const { isPreviewMode } = usePreviewMode()
     const { showCommandPalette, setShowCommandPalette, activeKeyboardShortcuts } = useShortcutContext()
     const [selectedShortcut, setSelectedShortcut] = useState<string>()
     const [searchValue, setSearchValue] = useState<string>()
@@ -188,7 +189,11 @@ const CommandPalette = ({ customButton, hideButton }: CommandPaletteProps) => {
                 }}
                 value={selectedShortcut}
                 onValueChange={setSelectedShortcut}
-                filter={(value, search) => (value.toLowerCase().includes(search.toLowerCase()) ? 1 : 0)}
+                filter={
+                    isPreviewMode
+                        ? (value, search) => (value.toLowerCase().includes(search.toLowerCase()) ? 1 : 0)
+                        : undefined
+                }
             >
                 <Searchbar>
                     <IconContainer>


### PR DESCRIPTION
Preview mode locked. This replaces the default fuzzy matching with an exact matching system which also bolds matches with the query in the command palette.

It will be enabled in preview mode, and will use the current default implementation of the fuzzy match in non-preview mode.

It will still bold matches in non-preview mode, it will just keep using the fuzzy filtering.

<img width="563" alt="image (3)" src="https://user-images.githubusercontent.com/31417618/211082944-5e37ff5e-9143-4f27-9522-066ed242db04.png">

