### PR TITLE
Make multi-key shortcuts in tooltips match command palette

### DIFF
--- a/frontend/src/components/radix/Tip.tsx
+++ b/frontend/src/components/radix/Tip.tsx
@@ -60,9 +60,7 @@ const Tip = ({
         shortcutLabel || shortcut ? (
             <Flex alignItems="center" justifyContent="center" gap={Spacing._8}>
                 {shortcutLabel}
-                {shortcut?.split('+').map((keyLabel) => (
-                    <KeyboardShortcutContainer key={keyLabel}>{keyLabel}</KeyboardShortcutContainer>
-                ))}
+                <KeyboardShortcutContainer>{shortcut}</KeyboardShortcutContainer>
             </Flex>
         ) : (
             content


### PR DESCRIPTION
<img width="244" alt="image" src="https://user-images.githubusercontent.com/31417618/211115462-2116da6c-f025-44ce-a94d-a1a2055b1f04.png">
