### PR TITLE
Add optimistic sorting based on updated_at

### DIFF
--- a/frontend/src/services/api/tasks.hooks.ts
+++ b/frontend/src/services/api/tasks.hooks.ts
@@ -299,6 +299,7 @@ export const useModifyTask = () => {
                     task.priority_normalized = data.priorityNormalized ?? task.priority_normalized
                     task.external_status = data.status ?? task.external_status
                     task.recurring_task_template_id = data.recurringTaskTemplateId ?? task.recurring_task_template_id
+                    task.updated_at = DateTime.utc().toISO()
                     if (data.external_priority_id) {
                         const newPriority = task.all_priorities?.find(
                             (priority) => priority.external_id === data.external_priority_id
@@ -321,6 +322,7 @@ export const useModifyTask = () => {
                     task.priority_normalized = data.priorityNormalized ?? task.priority_normalized
                     task.external_status = data.status ?? task.external_status
                     task.recurring_task_template_id = data.recurringTaskTemplateId ?? task.recurring_task_template_id
+                    task.updated_at = DateTime.utc().toISO()
                 })
                 queryClient.setQueryData('tasks_v4', updatedTasks)
             }
@@ -350,6 +352,7 @@ export const useModifyTask = () => {
                     task.body = data.body ?? task.body
                     task.priority_normalized = data.priorityNormalized ?? task.priority_normalized
                     task.external_status = data.status ?? task.external_status
+                    task.updated_at = DateTime.utc().toISO()
                     if (data.external_priority_id) {
                         const newPriority = task.all_priorities?.find(
                             (priority) => priority.external_id === data.external_priority_id


### PR DESCRIPTION
This was actually really strange to work on. I initially used `DateTime.now().toISO()` but I found out that because our sorting is based off of string compares, it doesn't really work to do this. So I had to use `DateTime.utc().toISO()` to match the format of our backend updated_at times which are all in UTC. Took wayy too long to figure this out.