### PR TITLE
Remove sentry error for missing recurring task templates

### DIFF
--- a/frontend/src/components/molecules/recurring-tasks/recurringTasks.utils.ts
+++ b/frontend/src/components/molecules/recurring-tasks/recurringTasks.utils.ts
@@ -1,5 +1,4 @@
 import { useMemo } from 'react'
-import * as Sentry from '@sentry/browser'
 import { DateTime } from 'luxon'
 import { EMPTY_MONGO_OBJECT_ID } from '../../../constants'
 import { useRecurringTaskTemplates } from '../../../services/api/recurring-tasks.hooks'
@@ -29,11 +28,7 @@ export const useGetRecurringTaskTemplateFromId = (templateId?: string): TRecurri
 
     return useMemo(() => {
         if (!recurringTaskTemplates || !templateId || templateId === EMPTY_MONGO_OBJECT_ID) return undefined
-        const recurringTaskTemplate = recurringTaskTemplates.find((rt) => rt.id === templateId)
-        if (!recurringTaskTemplate) {
-            Sentry.captureMessage('Recurring task has invalid template id: ' + templateId)
-        }
-        return recurringTaskTemplate
+        return recurringTaskTemplates.find((rt) => rt.id === templateId)
     }, [recurringTaskTemplates, templateId])
 }
 


### PR DESCRIPTION
These errors were being thrown because template IDs were still being sent with tasks even after the templates were deleted. The backend now unsets these IDs when a template is deleted, but there are still some tasks that have IDs attached and it is difficult to migrate them away because many users have these tasks.

After a discussed this with maz, we decided to just stop logging these as errors