### PR TITLE
Fix task sections appearing to take a long time to load

### DIFF
--- a/frontend/src/services/api/task-section.hooks.ts
+++ b/frontend/src/services/api/task-section.hooks.ts
@@ -29,7 +29,7 @@ export const useAddTaskSection = () => {
 
     return useQueuedMutation((data: TAddTaskSectionData) => addTaskSection(data), {
         tag: 'tasks',
-        invalidateTagsOnSettled: ['tasks'],
+        invalidateTagsOnSettled: ['tasks', 'settings'],
         onMutate: async (data) => {
             await queryClient.cancelQueries('tasks')
 


### PR DESCRIPTION
This was because we were not refetching settings when a new task section was created, which included the sorting preferences

https://user-images.githubusercontent.com/42781446/211950334-07c43c17-2e45-4cb6-b396-b9adf4c80ba2.mp4

