### PR TITLE
Fix folder creation redirect bug

### DIFF
--- a/frontend/src/services/api/task-section.hooks.ts
+++ b/frontend/src/services/api/task-section.hooks.ts
@@ -61,9 +61,7 @@ export const useAddTaskSection = () => {
                 section.optimisticId = undefined
             })
             queryClient.setQueryData('tasks', newSections)
-            console.log(window.location.pathname)
             if (window.location.pathname.includes(`tasks/${optimisticId}`)) {
-                console.log('replacing', window.location.pathname, 'with', location.pathname.replace(optimisticId, id))
                 navigate(window.location.pathname.replace(optimisticId, id), { replace: true })
             }
         },


### PR DESCRIPTION
Fixed an ancient bug where clicking a newly created task folder would redirect to the task inbox

(demo uses an extended backend delay)

https://user-images.githubusercontent.com/42781446/211964586-a2b3c010-322f-442e-9d7f-752c09a97446.mp4

closes FRO-922