### PR TITLE
Make sure due date text doesn't wrap

### DIFF
--- a/frontend/src/components/molecules/subtasks/Subtask.tsx
+++ b/frontend/src/components/molecules/subtasks/Subtask.tsx
@@ -27,6 +27,7 @@ export const RightContainer = styled.div`
     display: flex;
     align-items: center;
     gap: ${Spacing._12};
+    white-space: nowrap;
 `
 export const SubtaskContainer = styled.div<{ forceHoverStyle?: boolean; isDone?: boolean }>`
     display: flex;


### PR DESCRIPTION
Before
<img width="469" alt="Screen Shot 2023-01-13 at 3 52 31 PM" src="https://user-images.githubusercontent.com/9156543/212416993-f8d37441-ba4b-4963-bac4-9a421f977d53.png">
After
<img width="470" alt="Screen Shot 2023-01-13 at 3 54 14 PM" src="https://user-images.githubusercontent.com/9156543/212417225-da01eb45-2901-465f-8e92-4cd5fb0a8f26.png">
