### PR TITLE
Fix bug that disallowed switching from order by empty lists

### DIFF
--- a/frontend/src/components/views/DailyOverviewView.tsx
+++ b/frontend/src/components/views/DailyOverviewView.tsx
@@ -37,11 +37,13 @@ export const useGetCorrectlyOrderedOverviewLists = () => {
     const { lists, isLoading } = useOverviewLists()
     const [overviewAutomaticEmptySort] = useGTLocalStorage('overviewAutomaticEmptySort', false, true)
     if (overviewAutomaticEmptySort) {
-        lists.sort((a, b) => {
+        const listsCopy = [...lists]
+        listsCopy.sort((a, b) => {
             if (a.view_items.length === 0 && b.view_items.length > 0) return 1
             if (a.view_items.length > 0 && b.view_items.length === 0) return -1
             return 0
         })
+        return { lists: listsCopy, isLoading }
     }
     return { lists, isLoading }
 }
@@ -66,7 +68,7 @@ const DailyOverviewView = () => {
                 return ids
             })
         }
-    }, [overviewItemId, lists])
+    }, [overviewItemId, JSON.stringify(lists)])
 
     const selectFirstItem = () => {
         const firstNonEmptyView = lists?.find((list) => list.view_items.length > 0)


### PR DESCRIPTION
Previously switching from manual order to order by empty list did not work. This is because 'lists' was being sorted in place, and there was no logic that reverted the list to its previous state.