### PR TITLE
Remove underline from markdown editor

### DIFF
--- a/frontend/src/components/atoms/GTTextField/MarkdownEditor/MarkdownEditor.tsx
+++ b/frontend/src/components/atoms/GTTextField/MarkdownEditor/MarkdownEditor.tsx
@@ -37,7 +37,6 @@ const MarkdownEditor = (props: RichTextEditorProps) => {
             new RemirrorExtensions.StrikeExtension(),
             new RemirrorExtensions.TableExtension(),
             new RemirrorExtensions.TrailingNodeExtension(),
-            new RemirrorExtensions.UnderlineExtension(),
             new RemirrorExtensions.ImageExtension({ enableResizing: true }),
         ],
         content: props.value,

--- a/frontend/src/components/atoms/GTTextField/MarkdownEditor/Toolbar.tsx
+++ b/frontend/src/components/atoms/GTTextField/MarkdownEditor/Toolbar.tsx
@@ -28,13 +28,6 @@ const Toolbar = ({ actions }: ToolbarProps) => {
                 shortcut={`${CMD_CTRL.label}+I`}
             />
             <ToolbarButton
-                icon={icons.underline}
-                action={commands.toggleUnderline}
-                isActive={active.underline()}
-                shortcutLabel="Underline"
-                shortcut={`${CMD_CTRL.label}+U`}
-            />
-            <ToolbarButton
                 icon={icons.strikethrough}
                 action={commands.toggleStrike}
                 isActive={active.strike()}


### PR DESCRIPTION
Markdown doesn't support underlining, so underlines in the editor weren't being persisted once the user saved a task body

this just removes underline functionality from the editor and toolbar

![image](https://user-images.githubusercontent.com/42781446/212569099-f6c351f5-ac57-4c42-a37e-8d377c4260c4.png)
