### PR TITLE
Fix calendar glitching bug

### DIFF
--- a/frontend/src/components/views/CalendarView.tsx
+++ b/frontend/src/components/views/CalendarView.tsx
@@ -69,7 +69,7 @@ const CalendarView = ({
                 if (calendarType === 'day') {
                     setDate(DateTime.now())
                 } else {
-                    setDate(DateTime.now().minus({ days: date.weekday % 7 }))
+                    setDate(DateTime.now().minus({ days: DateTime.now().weekday % 7 }))
                 }
                 timeoutTimer.reset()
             }


### PR DESCRIPTION
There is a calendar bug where if the window is open for 20 minutes, the app will try to reset the date every second and flash between "today" and the correct date on the week calendar. This change ensures that the date is reset correctly, and only gets reset once every 20 minutes max.

[bug in slack](https://generaltask.slack.com/archives/C032FP8NXS6/p1672946635284739)