### PR TITLE
Linear comment bugfix

### DIFF
--- a/frontend/src/components/details/comments/Comment.tsx
+++ b/frontend/src/components/details/comments/Comment.tsx
@@ -51,7 +51,7 @@ const Comment = ({ comment, sourceName }: CommentProps) => {
             </TopContainer>
             <BodyContainer>
                 <GTTextField
-                    itemId={comment.user.ExternalID + comment.body}
+                    itemId={comment.user.ExternalID + comment.body + comment.created_at}
                     type={contentType}
                     value={comment.body}
                     onChange={emptyFunction}


### PR DESCRIPTION
I noticed that when you click between two linear tasks, if the comments were sent by the same user, they stayed the same until you unmounted the comment component. To fix this, I just changed the `itemId` so it reflects more info about the comment. Shouldn't have any more collisions.

https://user-images.githubusercontent.com/31417618/213035834-345a37ea-04e9-4cfc-b5dd-6dc0b06c333e.mov

