### PR TITLE
Always set to today when entering focus mode

### DIFF
--- a/frontend/src/components/screens/FocusModeScreen.tsx
+++ b/frontend/src/components/screens/FocusModeScreen.tsx
@@ -184,11 +184,12 @@ const getEventsCurrentlyHappening = (events: TEvent[]) => {
 }
 
 const FocusModeScreen = () => {
-    const { selectedEvent, setSelectedEvent, setIsPopoverDisabled, setIsCollapsed, setCalendarType } =
+    const { selectedEvent, setSelectedEvent, setIsPopoverDisabled, setIsCollapsed, setCalendarType, setDate } =
         useCalendarContext()
     useEffect(() => {
         setIsCollapsed(false)
         setCalendarType('day')
+        setDate(DateTime.local())
         setIsPopoverDisabled(true)
         return () => {
             setIsPopoverDisabled(false)

--- a/frontend/src/components/views/CalendarView.tsx
+++ b/frontend/src/components/views/CalendarView.tsx
@@ -58,7 +58,6 @@ const CalendarView = ({
     const { isPreviewMode } = usePreviewMode()
     useEffect(() => {
         setCalendarType(initialType)
-        setDate(DateTime.local())
         if (showMainHeader !== undefined) setShowMainHeader(showMainHeader)
         if (showDateHeader !== undefined) setShowDateHeader(showDateHeader)
         if (isInitiallyCollapsed !== undefined) setIsCollapsed(isInitiallyCollapsed)


### PR DESCRIPTION
This just adds a `setDate(DateTime.local())` to `CalendarView` which sets the date to today when opening/closing focus mode as well as on first load of the app (because `CalendarView` is mounted again when entering focus mode. Should fix the bug where focus mode is "stuck" on a past day.