### PR TITLE
Redirect to landing page when user cancels login

### DIFF
--- a/backend/api/login.go
+++ b/backend/api/login.go
@@ -82,7 +82,7 @@ func (api *API) Login(c *gin.Context) {
 func (api *API) LoginCallback(c *gin.Context) {
 	var redirectParams GoogleRedirectParams
 	if c.ShouldBind(&redirectParams) != nil || redirectParams.State == "" || redirectParams.Code == "" || redirectParams.Scope == "" {
-		c.JSON(400, gin.H{"detail": "missing query params"})
+		c.Redirect(302, config.GetConfigValue("HOME_URL"))
 		return
 	}
 

--- a/backend/api/login_test.go
+++ b/backend/api/login_test.go
@@ -10,6 +10,7 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 
+	"github.com/GeneralTask/task-manager/backend/config"
 	"github.com/GeneralTask/task-manager/backend/database"
 	"github.com/GeneralTask/task-manager/backend/external"
 	"github.com/stretchr/testify/assert"
@@ -120,10 +121,9 @@ func TestLoginCallback(t *testing.T) {
 		request, _ := http.NewRequest("GET", "/login/callback/", nil)
 		recorder := httptest.NewRecorder()
 		router.ServeHTTP(recorder, request)
-		assert.Equal(t, http.StatusBadRequest, recorder.Code)
-		body, err := io.ReadAll(recorder.Body)
-		assert.NoError(t, err)
-		assert.Equal(t, "{\"detail\":\"missing query params\"}", string(body))
+		assert.Equal(t, http.StatusFound, recorder.Code)
+		// check that we redirect to the home page
+		assert.Equal(t, config.GetConfigValue("HOME_URL"), recorder.Result().Header.Get("Location"))
 	})
 
 	t.Run("Idempotent", func(t *testing.T) {


### PR DESCRIPTION
Instead of displaying an error response when the user hits cancel during the login flow, redirect to the landing page

https://user-images.githubusercontent.com/42781446/213354991-ecb4b72d-5957-4cad-b8a3-112e55d4e95e.mp4

closes BACK-466

