### PR TITLE
Make fm icons fit on single line

### DIFF
--- a/frontend/src/components/screens/FocusModeScreen.tsx
+++ b/frontend/src/components/screens/FocusModeScreen.tsx
@@ -33,8 +33,10 @@ const FOCUS_MODE_WIDTH = '956px'
 const EventHeaderContainer = styled.div`
     display: flex;
 `
-const MarginLeftContainer = styled.div`
+const ActionsContainer = styled.div`
     margin-left: auto;
+    display: flex;
+    height: fit-content;
 `
 export const IconButton = styled(NoStyleButton)`
     padding: ${Spacing._8};
@@ -345,12 +347,12 @@ const FocusModeScreen = () => {
                                 <>
                                     <EventHeaderContainer>
                                         <GTHeader>{title || NO_TITLE}</GTHeader>
-                                        <MarginLeftContainer>
+                                        <ActionsContainer>
                                             <ExternalLinkButton link={chosenEvent.deeplink} />
                                             <IconButton onClick={onDelete}>
                                                 <Icon icon={icons.trash} />
                                             </IconButton>
-                                        </MarginLeftContainer>
+                                        </ActionsContainer>
                                     </EventHeaderContainer>
                                     <GTTitle>
                                         <TimeRange start={timeStart} end={timeEnd} />


### PR DESCRIPTION
Before:
<img width="620" alt="Screen Shot 2023-01-19 at 12 38 45 PM" src="https://user-images.githubusercontent.com/9156543/213519353-f11075c1-59d1-4b96-a222-d2808c1e1f26.png">
After:
<img width="634" alt="Screen Shot 2023-01-19 at 12 37 43 PM" src="https://user-images.githubusercontent.com/9156543/213519351-62e93887-f93b-477b-8632-93a4fb1ba006.png">

