### PR TITLE
Break text for long bodies in focus mode

### DIFF
--- a/frontend/src/components/screens/FocusModeScreen.tsx
+++ b/frontend/src/components/screens/FocusModeScreen.tsx
@@ -126,6 +126,7 @@ const BodyHeader = styled.div`
 `
 const Body = styled.div`
     ${Typography.body};
+    overflow-wrap: break-word;
 `
 const Subtitle = styled.div`
     ${Typography.subtitle};


### PR DESCRIPTION
Before:
<img width="675" alt="Screen Shot 2023-01-19 at 12 40 54 PM" src="https://user-images.githubusercontent.com/9156543/213519970-980ad11a-0e73-4a77-9d4f-8269b9953531.png">
After:
<img width="664" alt="Screen Shot 2023-01-19 at 12 41 43 PM" src="https://user-images.githubusercontent.com/9156543/213519972-e5638d55-0929-4dcb-9aaf-dc51e333adf4.png">
