### PR TITLE
Fix note bodies updating when you switch notes

### DIFF
--- a/frontend/src/components/notes/NoteDetails.tsx
+++ b/frontend/src/components/notes/NoteDetails.tsx
@@ -121,6 +121,7 @@ const NoteDetails = ({ note }: NoteDetailsProps) => {
             </DetailsTopContainer>
             <div>
                 <GTTextField
+                    key={note.id}
                     type="plaintext"
                     itemId={note.id}
                     value={note.title}
@@ -131,6 +132,7 @@ const NoteDetails = ({ note }: NoteDetailsProps) => {
                 />
             </div>
             <GTTextField
+                key={note.id}
                 type="markdown"
                 itemId={note.id}
                 value={note.body}

--- a/frontend/src/components/notes/SharedNoteView.tsx
+++ b/frontend/src/components/notes/SharedNoteView.tsx
@@ -151,6 +151,7 @@ const SharedNoteView = () => {
                                 <>
                                     <Flex alignItems="flex-start">
                                         <GTTextField
+                                            key={note.id}
                                             type="plaintext"
                                             itemId={note.title}
                                             value={note.title}
@@ -162,6 +163,7 @@ const SharedNoteView = () => {
                                         <NoteActionsDropdown note={note} isOwner={isUserNoteOwner} />
                                     </Flex>
                                     <GTTextField
+                                        key={note.id}
                                         type="markdown"
                                         itemId={note.body}
                                         value={note.body}


### PR DESCRIPTION
Turns out, itemId doesn't handle this anymore, key does. To maintain compatibility (because atlaskit is still feature-gated) we are using both key and itemId right now.