### PR TITLE
Fix useNavigateToTask selection

### DIFF
--- a/frontend/src/hooks/useNavigateToTask.ts
+++ b/frontend/src/hooks/useNavigateToTask.ts
@@ -1,5 +1,5 @@
 import { useCallback } from 'react'
-import { useLocation, useNavigate } from 'react-router-dom'
+import { useLocation, useNavigate, useParams } from 'react-router-dom'
 import { useCalendarContext } from '../components/calendar/CalendarContext'
 import Log from '../services/api/log'
 import { useGetOverviewViews } from '../services/api/overview.hooks'
@@ -12,11 +12,23 @@ const useNavigateToTask = () => {
     const { data: sectionsData } = useGetTasks()
     const navigate = useNavigate()
     const { setCalendarType } = useCalendarContext()
+    const params = useParams()
 
     const getTaskURL = useCallback(
         (taskID: string, views: TOverviewView[], sections: TTaskSection[], pathname: string, subtaskId?: string) => {
             const isUserOnOverviewPage = pathname.startsWith('/overview') || pathname.startsWith('/overview')
             if (isUserOnOverviewPage) {
+                // first check the current view
+                const currentView = views.find((view) => view.id === params.overviewViewId)
+                if (currentView) {
+                    const item = currentView.view_items.find((item) => item.id === taskID)
+                    if (item) {
+                        navigate(`/overview/${currentView.id}/${item.id}/${subtaskId}`)
+                        Log(`task_navigate__/overview/${currentView.id}/${item.id}/${subtaskId}`)
+                        return
+                    }
+                }
+                // otherwise check all views
                 for (const view of views) {
                     for (const item of view.view_items) {
                         if (item.id === taskID) {


### PR DESCRIPTION
fixed two cases
- in a task folder, marking a task done under a linear/slack task would bring you to the linear/slack pages
- in the daily overview page, useNavigateToTask would bring you to the first list with that task, so now we first check the current list before iterating through the rest

https://user-images.githubusercontent.com/42781446/213763937-21cbbaf5-a137-4e48-9d79-e8a8a3a28942.mov

