### PR TITLE
Make shared note work in preview mode

### DIFF
--- a/frontend/src/components/notes/SharedNoteView.tsx
+++ b/frontend/src/components/notes/SharedNoteView.tsx
@@ -6,7 +6,7 @@ import { DateTime } from 'luxon'
 import styled, { css } from 'styled-components'
 import { AUTHORIZATION_COOKE, LOGIN_URL } from '../../constants'
 import getEnvVars from '../../environment'
-import { useAuthWindow } from '../../hooks'
+import { useAuthWindow, usePreviewMode } from '../../hooks'
 import useAnalyticsEventTracker from '../../hooks/useAnalyticsEventTracker'
 import { useGetNote, useGetNotes } from '../../services/api/notes.hooks'
 import { Border, Colors, Shadows, Spacing } from '../../styles'
@@ -95,6 +95,7 @@ const SharedNoteView = () => {
     const { openAuthWindow } = useAuthWindow()
     const navigate = useNavigate()
     const { noteId } = useParams()
+    const { isLoading: isPreviewModeLoading } = usePreviewMode()
     const isLoggedIn = !!Cookies.get(AUTHORIZATION_COOKE)
 
     const { data: note, isLoading } = useGetNote({ id: noteId ?? '' })
@@ -104,7 +105,7 @@ const SharedNoteView = () => {
 
     if (!noteId) navigate('/')
 
-    if (isLoading || isLoadingNotes) return <Spinner />
+    if (isLoading || isLoadingNotes || isPreviewModeLoading) return <Spinner />
     return (
         <>
             {note && (

--- a/frontend/src/hooks/usePreviewMode.ts
+++ b/frontend/src/hooks/usePreviewMode.ts
@@ -3,17 +3,19 @@ import { useGetUserInfo } from '../services/api/user-info.hooks'
 
 interface UsePreviewModeOutput {
     isPreviewMode: boolean
+    isLoading: boolean
     toggle: () => void
     enable: () => void
     disable: () => void
 }
 
 function usePreviewMode(defaultValue?: boolean): UsePreviewModeOutput {
-    const { data: userInfo } = useGetUserInfo()
+    const { data: userInfo, isLoading } = useGetUserInfo()
     const [isPreviewMode, setPreviewMode] = useGTLocalStorage<boolean>('previewMode', defaultValue ?? false, true)
 
     return {
         isPreviewMode: isPreviewMode && (userInfo?.is_employee ?? false),
+        isLoading,
         toggle: () => setPreviewMode((prev) => !prev),
         enable: () => setPreviewMode(true),
         disable: () => setPreviewMode(false),


### PR DESCRIPTION
basically preview mode was flipping from off -> on, which caused the rich text editor to change and break the page while in preview mode

look it works 
![image](https://user-images.githubusercontent.com/42781446/213790955-a8e6ad3e-dd81-4cbc-83ee-e0449f8e9d93.png)
