### PR TITLE
Increase Kube resource limit

### DIFF
--- a/kubernetes/manifests/prod/prd-application-deployment.yaml
+++ b/kubernetes/manifests/prod/prd-application-deployment.yaml
@@ -18,10 +18,10 @@ spec:
           resources:
             requests:
               memory: "2Gi"
-              cpu: "1024m"
+              cpu: "1000m"
             limits:
               memory: "2Gi"
-              cpu: "2048m"
+              cpu: "2000m"
           imagePullPolicy: Always
           name: "core"
           env:


### PR DESCRIPTION
Did some looking. Looks like our pods should be provisioned to handle 2000m limit. Switched from 1024m to 1000m as well, because it seems like 1000m matches 1 core: https://www.stacksimplify.com/aws-eks/kubernetes-concepts/learn-kubernetes-requests-and-limits-on-aws-eks/

It seems like this could be potentially responsible for some of our slowdowns. I think when the requests matches the limit, it can sometimes do some weird things with multithreading. The alternative is to remove the limit entirely, which is what some people recommend, but I think that's riskier than just upping the limit. If this doesn't fix the issue, however, I think it might be worthwhile to look into removing the limits alltogether.