### PR TITLE
Fix rich text overflow

### DIFF
--- a/frontend/src/components/atoms/GTTextField/AtlassianEditor/AtlassianEditor.tsx
+++ b/frontend/src/components/atoms/GTTextField/AtlassianEditor/AtlassianEditor.tsx
@@ -5,8 +5,8 @@ import Editor from './Editor'
 import Toolbar from './Toolbar'
 
 const EditorAndToolbarContainer = styled.div`
-    height: 100%;
     display: flex;
+    height: 100%;
     flex-direction: column;
     :not(:focus-within) {
         .toolbar {

--- a/frontend/src/components/atoms/GTTextField/AtlassianEditor/Editor.tsx
+++ b/frontend/src/components/atoms/GTTextField/AtlassianEditor/Editor.tsx
@@ -4,13 +4,16 @@ import { MarkdownTransformer } from '@atlaskit/editor-markdown-transformer'
 import adf2md from 'adf-to-md'
 import styled from 'styled-components'
 import { Spacing } from '../../../../styles'
+import { TOOLBAR_HEIGHT } from '../toolbar/styles'
 import { RichTextEditorProps } from '../types'
 
 const serializer = new JSONTransformer()
 
 const EditorContainer = styled.div`
-    flex: 1;
-    padding: ${Spacing._8} ${Spacing._8} 0;
+    height: 100%;
+    :focus-within {
+        height: calc(100% - ${TOOLBAR_HEIGHT});
+    }
     box-sizing: border-box;
     /* height: 100%s needed to make editor match container height so entire area is clickable */
     > div > :nth-child(2) {
@@ -24,8 +27,14 @@ const EditorContainer = styled.div`
     }
     && .ProseMirror {
         height: 100%;
+        padding: ${Spacing._8};
+        box-sizing: border-box;
         > * {
-            margin: ${Spacing._8} 0;
+            padding-bottom: ${Spacing._8};
+            margin: 0;
+        }
+        > .code-block {
+            margin: 0;
         }
     }
     .assistive {

--- a/frontend/src/components/atoms/GTTextField/toolbar/styles.ts
+++ b/frontend/src/components/atoms/GTTextField/toolbar/styles.ts
@@ -1,11 +1,14 @@
 import styled from 'styled-components'
 import { Border, Colors, Spacing } from '../../../../styles'
 
+export const TOOLBAR_HEIGHT = '40px'
+
 export const MenuContainer = styled.div`
     display: flex;
+    height: ${TOOLBAR_HEIGHT};
     align-items: center;
     background-color: ${Colors.background.medium};
-    padding: ${Spacing._4} ${Spacing._8};
+    padding: 0 ${Spacing._8};
     border-bottom-left-radius: ${Border.radius.small};
     border-bottom-right-radius: ${Border.radius.small};
     gap: ${Spacing._8};


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/42781446/213830555-88a61ba5-a2bc-410a-b767-7a95ba2e920e.png)

After:
![image](https://user-images.githubusercontent.com/42781446/213830504-0d655ab1-8bc5-49c1-82b3-aa655a51ff6a.png)
![image](https://user-images.githubusercontent.com/42781446/213830510-7ebe807a-63f2-4724-ab9f-8d1eb479d68a.png)

literally nothing with rich text is every simple smh