### PR TITLE
Fix schedule task dropdown width issue

### DIFF
--- a/frontend/src/components/radix/GTDropdownMenu.tsx
+++ b/frontend/src/components/radix/GTDropdownMenu.tsx
@@ -29,7 +29,7 @@ const DropdownMenuContent = styled(DropdownMenu.Content)<{
     ${MenuContentShared};
     ${({ $menuInModal }) => $menuInModal && `z-index: 1000;`}
     ${({ $width }) => $width && `width: ${$width}px;`}
-    ${({ $width }) => ($width ? `max-width: ${$width}px;` : `max-width: ${DROPDOWN_MENU_ITEM_MAX_WIDTH};`)}
+    max-width: ${({ $width }) => ($width ? `${$width}px` : `${DROPDOWN_MENU_ITEM_MAX_WIDTH}`)};
     ${({ $textColor }) => $textColor && `color: ${$textColor};`}
     ${({ $fontStyle }) => $fontStyle && Typography[$fontStyle]};
     box-sizing: border-box;


### PR DESCRIPTION
Before:
<img width="337" alt="Screenshot 2023-01-20 at 5 08 48 PM" src="https://user-images.githubusercontent.com/31417618/213831250-c89ea7d0-5022-451b-8267-59ed41706dc5.png">
After:
<img width="344" alt="Screenshot 2023-01-20 at 5 08 35 PM" src="https://user-images.githubusercontent.com/31417618/213831237-02a32def-0436-4654-8e13-246e08dda8fb.png">
