### PR TITLE
Hide underline in markdown mode

### DIFF
--- a/frontend/src/components/atoms/GTTextField/AtlassianEditor/Editor.tsx
+++ b/frontend/src/components/atoms/GTTextField/AtlassianEditor/Editor.tsx
@@ -9,7 +9,7 @@ import { RichTextEditorProps } from '../types'
 
 const serializer = new JSONTransformer()
 
-const EditorContainer = styled.div`
+const EditorContainer = styled.div<{ isMarkdown: boolean }>`
     height: 100%;
     :focus-within {
         height: calc(100% - ${TOOLBAR_HEIGHT});


### PR DESCRIPTION
The underline toolbar button was already removed in markdown mode, but Cmd+U still enabled it in the editor. This is a workaround to just hide the underline while in markdown mode since it will not be persisted anyways

![image](https://user-images.githubusercontent.com/42781446/213839759-b8725053-27e1-42e4-9f84-456533d89d65.png)
