### PR TITLE
Fix due date bug causing 0 epoch time to show

### DIFF
--- a/frontend/src/utils/utils.ts
+++ b/frontend/src/utils/utils.ts
@@ -207,7 +207,8 @@ export const getFormattedDate = (
     textColor: TTextColor
     iconColor: TIconColor
 } => {
-    if (!date || !date.isValid) {
+    // Empty due dates are represented using 0 epoch time
+    if (!date || !date.isValid || +date === 0) {
         return { dateString: 'No due date', textColor: 'light', iconColor: 'gray' }
     }
     if (date.hasSame(DateTime.local(), 'day')) {


### PR DESCRIPTION
Previously when a user unset a due date, the optimistic date showed `Thursday, January 1, 1970 12:00:00 AM`

https://user-images.githubusercontent.com/9156543/214106830-7a68c5c7-13f6-47e9-9e34-a5c9517b0781.mov



