### PR TITLE
Fix slack task page bug

### DIFF
--- a/frontend/src/components/views/SlackTasksView.tsx
+++ b/frontend/src/components/views/SlackTasksView.tsx
@@ -29,8 +29,11 @@ const SlackTasksView = () => {
     const navigate = useNavigate()
 
     const slackTasks = useMemo(() => {
-        const tasks = taskSections?.flatMap((section) => section.tasks) ?? []
-        return tasks.filter((task) => task.source.name === 'Slack' && (!task.is_done || task.optimisticId))
+        const tasks =
+            taskSections
+                ?.filter((section) => !section.is_done && !section.is_trash)
+                .flatMap((section) => section.tasks) ?? []
+        return tasks.filter((task) => task.source.name === 'Slack')
     }, [taskSections])
 
     const { data: linkedAccounts } = useGetLinkedAccounts()


### PR DESCRIPTION
Initial "bug" was that the count for slack tasks was wrong, it would show 0 even with 5 slack tasks on the slack page. Checked in with Julian who initially reported the bug, and I found out that all the slack tasks showing up were deleted. As it turns out, the count on the sidebar excluded deleted and done tasks, but they still showed in the slack view.

This PR just hides deleted/done tasks from the slack page. No screenshots because I **STILL** can't link my slack account in dev :)