### PR TITLE
Stop using jira editor for markdown in preview mode

### DIFF
--- a/frontend/src/components/atoms/GTTextField/GTTextField.tsx
+++ b/frontend/src/components/atoms/GTTextField/GTTextField.tsx
@@ -1,6 +1,5 @@
 import { Suspense, forwardRef, lazy, useRef } from 'react'
 import styled from 'styled-components'
-import { usePreviewMode } from '../../../hooks'
 import { Border, Colors, Shadows } from '../../../styles'
 import { stopKeydownPropogation } from '../../../utils/utils'
 import Spinner from '../Spinner'
@@ -56,15 +55,11 @@ const Container = styled.div<{
 
 const GTTextField = forwardRef((props: GTTextFieldProps, ref) => {
     const containerRef = useRef<HTMLDivElement>(null)
-    const { isPreviewMode } = usePreviewMode()
 
     const getEditor = () => {
         if (props.type === 'plaintext') {
             return <PlainTextEditor ref={ref} {...props} />
         } else if (props.type === 'markdown') {
-            if (isPreviewMode) {
-                return <AtlassianEditor {...props} />
-            }
             return <MarkdownEditor {...props} />
         } else if (props.type === 'atlassian') {
             return <AtlassianEditor {...props} />


### PR DESCRIPTION
since this has been slightly deprioritized, stop using jira editor for markdown in preview mode so app doesn't crash when toggling preview mode

https://user-images.githubusercontent.com/42781446/214386811-1510f995-6368-4877-9dfb-a63ffcc9c4b4.mov

