### PR TITLE
Increase auth window interval duration

### DIFF
--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -19,7 +19,6 @@ export const EVENTS_REFETCH_INTERVAL = 60 * 1000
 export const ONE_MINUTE_INTERVAL = 60 * 1000
 export const FIVE_MINUTE_INTERVAL = 5 * 60 * 1000
 export const FIFTEEN_MINUTE_INTERVAL = 15 * 60 * 1000
-export const ONE_SECOND = 1 * 1000
 export const FIVE_SECOND_TIMEOUT = 5 * 1000
 export const NOTE_SYNC_TIMEOUT = 1 * 1000
 export const PR_REFETCH_INTERVAL = 120 * 1000

--- a/frontend/src/hooks/useAuthWindow.ts
+++ b/frontend/src/hooks/useAuthWindow.ts
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { useQueryClient } from 'react-query'
 import Cookie from 'js-cookie'
-import { AUTHORIZATION_COOKE, COOKIE_DOMAIN, GOOGLE_AUTH_ROUTE, ONE_SECOND } from '../constants'
+import { AUTHORIZATION_COOKE, COOKIE_DOMAIN, GOOGLE_AUTH_ROUTE, SINGLE_SECOND_INTERVAL } from '../constants'
 import getEnvVars from '../environment'
 import Log from '../services/api/log'
 
@@ -64,7 +64,7 @@ const useAuthWindow = () => {
                 if (win.closed) {
                     onClose(timer)
                 }
-            }, ONE_SECOND)
+            }, SINGLE_SECOND_INTERVAL)
         }
     }
 


### PR DESCRIPTION
The default interval duration for `setInterval` is 0, so whenever an auth window was open in the app we were running an infinite loop that was very CPU intensive

(i noticed my firefox was taking a ton of CPU bc the popup windows actually work there)


https://user-images.githubusercontent.com/42781446/214407104-04fee64a-1121-4031-a475-658fa20ca522.mov


