### PR TITLE
Remove "join current meeting" shortcut from command palette if there is no current meeting to join

### DIFF
--- a/frontend/src/hooks/useEventBanners.tsx
+++ b/frontend/src/hooks/useEventBanners.tsx
@@ -97,6 +97,7 @@ export default function useEventBanners(date: DateTime) {
             if (currentMeeting?.conference_call.url) {
                 window.open(currentMeeting.conference_call.url, '_blank')
             }
-        }, [])
+        }, [eventsWithinTenMinutes]),
+        !eventsWithinTenMinutes.current.find((event) => isEventWithinTenMinutes(event))?.conference_call.url
     )
 }


### PR DESCRIPTION
<img width="1154" alt="Screenshot 2023-01-25 at 11 24 24 AM" src="https://user-images.githubusercontent.com/31417618/214666375-f63ff733-0f29-495e-b670-4d80764e2e24.png">
<img width="1144" alt="Screenshot 2023-01-25 at 11 25 06 AM" src="https://user-images.githubusercontent.com/31417618/214666595-a89c15a4-6b55-4beb-82de-e8ec6f62be15.png">
