### PR TITLE
Fix calendar shortcut navigation

### DIFF
--- a/frontend/src/components/views/CalendarView.tsx
+++ b/frontend/src/components/views/CalendarView.tsx
@@ -45,8 +45,16 @@ const CalendarView = ({
     const [showMainHeader, setShowMainHeader] = useState<boolean>(initialShowMainHeader ?? true)
     const [showDateHeader, setShowDateHeader] = useState<boolean>(initialShowDateHeader ?? true)
     const timeoutTimer = useIdleTimer({}) // default timeout is 20 minutes
-    const { date, calendarType, isCollapsed, setDate, setCalendarType, setIsCollapsed, setShowTaskToCalSidebar } =
-        useCalendarContext()
+    const {
+        date,
+        calendarType,
+        isCollapsed,
+        setDate,
+        setCalendarType,
+        setIsCollapsed,
+        setShowTaskToCalSidebar,
+        dayViewDate,
+    } = useCalendarContext()
     const monthBlocks = useMemo(() => {
         const blocks = getMonthsAroundDate(date, 1)
         return blocks.map((block) => ({ startISO: block.start.toISO(), endISO: block.end.toISO() }))
@@ -94,6 +102,7 @@ const CalendarView = ({
         'showDailyCalendar',
         useCallback(() => {
             setIsCollapsed(false)
+            setDate(dayViewDate)
             setCalendarType('day')
         }, [calendarType, setCalendarType, setIsCollapsed]),
         isFocusMode
@@ -102,6 +111,7 @@ const CalendarView = ({
         'showWeeklyCalendar',
         useCallback(() => {
             setIsCollapsed(false)
+            setDate(date.minus({ days: date.weekday % 7 }))
             setCalendarType('week')
         }, [calendarType, setCalendarType, setIsCollapsed]),
         isFocusMode


### PR DESCRIPTION
Just makes it reset the date when switching modes, the same way the toggle button does.