### PR TITLE
Rename needs_multical_scopes -> has_multical_scopes in /calendars/ response

### DIFF
--- a/backend/api/calendar_list.go
+++ b/backend/api/calendar_list.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+
 	"github.com/GeneralTask/task-manager/backend/database"
 	"github.com/gin-gonic/gin"
 	"go.mongodb.org/mongo-driver/bson"
@@ -16,7 +17,7 @@ type CalendarResult struct {
 type CalendarAccountResult struct {
 	AccountID        string           `json:"account_id"`
 	Calendars        []CalendarResult `json:"calendars"`
-	HasMulticalScope bool             `json:"needs_multical_scopes"`
+	HasMulticalScope bool             `json:"has_multical_scopes"`
 }
 
 func (api *API) CalendarsList(c *gin.Context) {


### PR DESCRIPTION
this endpoint was sending `needs_multical_scopes: false` for accounts that needed multical scopes, so renamed for clarity