### PR TITLE
Fix calendar going to wrong date when collapsed

### DIFF
--- a/frontend/src/components/calendar/CalendarContext.tsx
+++ b/frontend/src/components/calendar/CalendarContext.tsx
@@ -80,9 +80,12 @@ export const CalendarContextProvider = (props: CalendarContextProviderProps) => 
     const collapseAndSetType = useCallback(
         (isCollapsed: boolean) => {
             setIsCollapsed(isCollapsed)
-            if (isCollapsed) setCalendarType('day')
+            if (isCollapsed) {
+                setCalendarType('day')
+                setDate(dayViewDate)
+            }
         },
-        [setIsCollapsed, setCalendarType]
+        [dayViewDate, setIsCollapsed, setCalendarType]
     )
 
     const value = {


### PR DESCRIPTION
Previously, if you 
- open week view
- collapse calendar sidebar
- reopen calendar sidebar (which opens daily view)
- it would show sunday instead of the current day


before and after:

https://user-images.githubusercontent.com/42781446/214966973-48604464-dce1-419b-9132-97d18df91f05.mov

