### PR TITLE
Fix linear icon offset bug

### DIFF
--- a/frontend/src/components/atoms/buttons/GTButton.tsx
+++ b/frontend/src/components/atoms/buttons/GTButton.tsx
@@ -4,7 +4,6 @@ import { Border, Colors, Shadows, Spacing, Typography } from '../../../styles'
 import { TIconColor, TTextColor } from '../../../styles/colors'
 import { icons } from '../../../styles/images'
 import { Icon } from '../Icon'
-import { Truncated } from '../typography/Typography'
 import NoStyleButton from './NoStyleButton'
 
 type TButtonStyle = 'primary' | 'secondary' | 'simple'
@@ -149,7 +148,7 @@ const GTButton = ({
             {...rest}
         >
             {icon && <Icon icon={icon} color={iconColor} colorHex={iconColorHex} />}
-            <Truncated>{value}</Truncated>
+            {value}
             {isDropdown && (
                 <MarginLeftAuto>
                     <Icon icon={icons.caret_down_solid} color="gray" />

--- a/frontend/src/components/calendar/CalendarSelector.tsx
+++ b/frontend/src/components/calendar/CalendarSelector.tsx
@@ -6,6 +6,7 @@ import { TCalendar, TCalendarAccount } from '../../utils/types'
 import { EMPTY_ARRAY } from '../../utils/utils'
 import GTButton from '../atoms/buttons/GTButton'
 import GTIconButton from '../atoms/buttons/GTIconButton'
+import { Truncated } from '../atoms/typography/Typography'
 import GTDropdownMenu from '../radix/GTDropdownMenu'
 import { DEFAULT_CALENDAR_COLOR, calendarColors } from './utils/colors'
 
@@ -88,7 +89,7 @@ const CalendarSelector = ({ mode }: CalendarSelectorProps) => {
                     <GTIconButton icon={icons.eye} tooltipText="Show/hide calendars" asDiv />
                 ) : (
                     <GTButton
-                        value={selectedTaskToCalCalendar?.title || 'Select a calendar'}
+                        value={<Truncated>{selectedTaskToCalCalendar?.title || 'Select a calendar'}</Truncated>}
                         icon={icons.square}
                         iconColorHex={
                             calendarColors[selectedTaskToCalCalendar?.color_id as keyof typeof calendarColors]


### PR DESCRIPTION
Fixes following bug: ![image](https://user-images.githubusercontent.com/9156543/215019668-f0221741-a6b0-4bb6-8cd7-efa1a5b7d230.png)

Bug was caused by diff #2846. I moved the truncated span up a component, @scottmai lmk if you see any problems with this since you worked on calendar selection logic.
