### PR TITLE
Refetch smart prioritization remaining suggestions when smart prioritize fails

### DIFF
--- a/frontend/src/components/overview/EditModal/SmartPrioritize.tsx
+++ b/frontend/src/components/overview/EditModal/SmartPrioritize.tsx
@@ -110,7 +110,7 @@ const SmartPrioritize = ({ state, setState }: SmartPrioritizeProps) => {
                         <Label color="red">
                             There was an error sorting your lists.{' '}
                             {hasSuggestionsRemaining
-                                ? `Please try again (${suggestionsRemaining} uses remaining)`
+                                ? `Please try again (${suggestionsRemaining} uses remaining).`
                                 : null}
                         </Label>
                         <GTButton


### PR DESCRIPTION
we weren't refetching if the prioritization failed 

Also disabled Retry button if the user is out of uses (hopefully this shouldn't happen anymore after julian's limit PR)



https://user-images.githubusercontent.com/42781446/215234710-d24bf863-62e0-44e1-bd01-5cd6e6aaffb8.mov



