### PR TITLE
Fix hanging recurring task backfill request

### DIFF
--- a/backend/api/recurring_task_template_backfill.go
+++ b/backend/api/recurring_task_template_backfill.go
@@ -211,7 +211,7 @@ func (api *API) countTasksToCreateForWeeklyTemplate(currentTime time.Time, lastB
 		dayToCreateTask = int(time.Sunday)
 	}
 	// continue adding days until the weekday matches the day of the week which the trigger is
-	for int(validCreationTime.Weekday()) < dayToCreateTask {
+	for int(validCreationTime.Weekday()) != dayToCreateTask {
 		validCreationTime = validCreationTime.AddDate(0, 0, 1)
 	}
 


### PR DESCRIPTION
For recurring tasks that repeat weekly on sunday, frontend was sending a `day_to_create_task` of `7`, but Go counts Sunday as `0`. This caused an infinite loop in the backflll request. We probably should add more validation but this should work for now.

This demo shows the current behavior, where a recurring task on sunday causes the backfill request to hang, then executes immediately with the change in this PR.

https://user-images.githubusercontent.com/42781446/215354909-cd9483b0-fa79-443b-a66f-d18661dbe849.mov

