### PR TITLE
Put done folder above trash in collapsed nav

### DIFF
--- a/frontend/src/components/views/NavigationViewCollapsed.tsx
+++ b/frontend/src/components/views/NavigationViewCollapsed.tsx
@@ -175,18 +175,6 @@ const NavigationViewCollapsed = ({ setIsCollapsed }: NavigationViewCollapsedProp
                             }
                         />
                     )}
-                    {TRASH_FOLDER && (
-                        <NavigationLink
-                            link={`/tasks/${TRASH_SECTION_ID}`}
-                            title={TRASH_FOLDER_NAME}
-                            icon={icons.trash}
-                            isCurrentPage={sectionId === TRASH_SECTION_ID}
-                            taskSection={TRASH_FOLDER}
-                            count={TRASH_FOLDER.tasks.length}
-                            isCollapsed
-                            droppable
-                        />
-                    )}
                     {DONE_FOLDER && (
                         <NavigationLink
                             link={`/tasks/${DONE_SECTION_ID}`}
@@ -195,6 +183,18 @@ const NavigationViewCollapsed = ({ setIsCollapsed }: NavigationViewCollapsedProp
                             isCurrentPage={sectionId === DONE_SECTION_ID}
                             taskSection={DONE_FOLDER}
                             count={DONE_FOLDER.tasks.length}
+                            isCollapsed
+                            droppable
+                        />
+                    )}
+                    {TRASH_FOLDER && (
+                        <NavigationLink
+                            link={`/tasks/${TRASH_SECTION_ID}`}
+                            title={TRASH_FOLDER_NAME}
+                            icon={icons.trash}
+                            isCurrentPage={sectionId === TRASH_SECTION_ID}
+                            taskSection={TRASH_FOLDER}
+                            count={TRASH_FOLDER.tasks.length}
                             isCollapsed
                             droppable
                         />


### PR DESCRIPTION
These were in the wrong order. Not sure how long it's been like this. I just updated them to put them in the same order as the non-collapsed nav.
<img width="82" alt="Screenshot 2023-01-31 at 3 15 38 PM" src="https://user-images.githubusercontent.com/31417618/215872561-78da4280-72b7-48c1-8696-fc5c0e5f5562.png">
