### PR TITLE
Fix styling for multical dropdown button

### DIFF
--- a/frontend/src/components/atoms/buttons/GTButton.tsx
+++ b/frontend/src/components/atoms/buttons/GTButton.tsx
@@ -103,6 +103,12 @@ const Button = styled(NoStyleButton)<{
     ${(props) => props.textColor && `color: ${Colors.text[props.textColor]};`}
     ${(props) => props.disabled && `cursor: default;`}
 `
+const ButtonText = styled.span`
+    flex-shrink: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+`
 const MarginLeftAuto = styled.div`
     margin-left: auto;
 `
@@ -136,6 +142,7 @@ const GTButton = ({
     asDiv = false,
     ...rest
 }: GTButtonProps) => {
+    const formattedValue = typeof value === 'string' ? <ButtonText>{value}</ButtonText> : value
     return (
         <Button
             styleType={styleType}
@@ -148,7 +155,7 @@ const GTButton = ({
             {...rest}
         >
             {icon && <Icon icon={icon} color={iconColor} colorHex={iconColorHex} />}
-            {value}
+            {formattedValue}
             {isDropdown && (
                 <MarginLeftAuto>
                     <Icon icon={icons.caret_down_solid} color="gray" />


### PR DESCRIPTION
I noticed that the styling was off for the dropdown button. The issue made it so that there wasn't enough padding on the left side for the color square.

Before:
<img width="194" alt="Screenshot 2023-02-01 at 10 31 31 AM" src="https://user-images.githubusercontent.com/9156543/216087661-9c952ee8-d0f7-4df0-824c-4c20e1702fa0.png">
After:
<img width="204" alt="Screenshot 2023-02-01 at 10 31 08 AM" src="https://user-images.githubusercontent.com/9156543/216087659-4323d74d-4132-4230-903c-3043ef312c76.png">

