### PR TITLE
Increase default list show size from 5 to 10

### DIFF
--- a/frontend/src/components/overview/OverviewViewContainer.tsx
+++ b/frontend/src/components/overview/OverviewViewContainer.tsx
@@ -12,7 +12,8 @@ import MeetingPreparationViewItems from './viewItems/MeetingPreparationViewItems
 import PullRequestViewItems from './viewItems/PullRequestViewItems'
 import TaskSectionViewItems from './viewItems/TaskSectionViewItems'
 
-export const PAGE_SIZE = 10
+export const INITIAL_PAGE_SIZE = 10
+export const PAGE_SIZE = 5
 
 interface OverviewViewProps {
     view: TOverviewView
@@ -54,7 +55,7 @@ const OverviewView = ({ view, scrollRef }: OverviewViewProps) => {
                 // Ensure that visibleItemsCount <= view.view_items.length, and that we do not decrease the number of visible items when selecting a new item
                 Math.min(visibleItemsCount, view.view_items.length),
                 // If view.view_items.length drops below PAGE_SIZE, set visibleItemsCount to view.view_items.length
-                Math.min(view.view_items.length, PAGE_SIZE),
+                Math.min(view.view_items.length, INITIAL_PAGE_SIZE),
                 // if the selected item is in this view, ensure it is visible
                 view.id === overviewViewId ? view.view_items.findIndex((item) => item.id === overviewItemId) + 1 : 0
             )

--- a/frontend/src/hooks/useGetVisibleItemCount.ts
+++ b/frontend/src/hooks/useGetVisibleItemCount.ts
@@ -1,6 +1,6 @@
 import { useLayoutEffect, useState } from 'react'
 import { useParams } from 'react-router-dom'
-import { PAGE_SIZE } from '../components/overview/OverviewViewContainer'
+import { INITIAL_PAGE_SIZE } from '../components/overview/OverviewViewContainer'
 import { TOverviewView } from '../utils/types'
 
 const useGetVisibleItemCount = (list: TOverviewView, listID: string) => {
@@ -13,7 +13,7 @@ const useGetVisibleItemCount = (list: TOverviewView, listID: string) => {
                 // Ensure that visibleItemsCount <= view.view_items.length, and that we do not decrease the number of visible items when selecting a new item
                 Math.min(visibleItemsCount, list.view_items.length),
                 // If view.view_items.length drops below PAGE_SIZE, set visibleItemsCount to view.view_items.length
-                Math.min(list.view_items.length, PAGE_SIZE),
+                Math.min(list.view_items.length, INITIAL_PAGE_SIZE),
                 // if the selected item is in this view, ensure it is visible
                 list.id === overviewViewId ? list.view_items.findIndex((item) => item.id === overviewItemId) + 1 : 0
             )


### PR DESCRIPTION
<img width="499" alt="Screenshot 2023-02-01 at 3 35 22 PM" src="https://user-images.githubusercontent.com/31417618/216157464-55fe0e56-8853-43e7-9091-a81c23c29ac1.png">

Still shows "new pages" 5 tasks at a time, but shows 10 initially.