### PR TITLE
Update "due today" empty state

### DIFF
--- a/frontend/src/components/overview/viewItems/DueTodayViewItems.tsx
+++ b/frontend/src/components/overview/viewItems/DueTodayViewItems.tsx
@@ -1,14 +1,17 @@
 import { Ref, forwardRef } from 'react'
 import { useParams } from 'react-router-dom'
+import { usePreviewMode } from '../../../hooks'
 import { TTask } from '../../../utils/types'
 import Task from '../../molecules/Task'
 import { ViewHeader, ViewName } from '../styles'
+import EmptyListMessage from './EmptyListMessage'
 import EmptyViewItem from './EmptyViewItem'
 import { ViewItemsProps } from './viewItems.types'
 
 const DueTodayViewItems = forwardRef(
     ({ view, visibleItemsCount, scrollRef, hideHeader }: ViewItemsProps, ref: Ref<HTMLDivElement>) => {
         const { overviewViewId, overviewItemId } = useParams()
+        const { isPreviewMode } = usePreviewMode()
         return (
             <>
                 {!hideHeader && (
@@ -30,6 +33,8 @@ const DueTodayViewItems = forwardRef(
                                 link={`/overview/${view.id}/${item.id}`}
                             />
                         ))
+                ) : isPreviewMode ? (
+                    <EmptyListMessage list={view} />
                 ) : (
                     <EmptyViewItem
                         header="You have no more tasks due today."

--- a/frontend/src/components/overview/viewItems/EmptyListMessage.tsx
+++ b/frontend/src/components/overview/viewItems/EmptyListMessage.tsx
@@ -28,7 +28,7 @@ const emptyListMessage = (list: TOverviewView) => {
         case 'slack':
             return 'Saved messages will appear here.'
         case 'due_today':
-            return 'Tasks due today will appear here.'
+            return 'Tasks which are due today will appear here.'
         default:
             return ''
     }


### PR DESCRIPTION
<img width="502" alt="Screenshot 2023-02-01 at 3 45 18 PM" src="https://user-images.githubusercontent.com/31417618/216159310-423b9929-ad1f-4ae1-946c-238633499f23.png">

This PR just brings the due today message inline with the other redesigned empty states because it was left out when we conditionally rendered these based on preview mode.