### PR TITLE
Move auto empty list sort logic to useOverviewLists

### DIFF
--- a/frontend/src/components/overview/OverviewDetails.tsx
+++ b/frontend/src/components/overview/OverviewDetails.tsx
@@ -4,10 +4,10 @@ import { TPullRequest, TTask } from '../../utils/types'
 import EmptyDetails from '../details/EmptyDetails'
 import PullRequestDetails from '../details/PullRequestDetails'
 import TaskDetails from '../details/TaskDetails'
-import { useGetCorrectlyOrderedOverviewLists } from '../views/DailyOverviewView'
+import useOverviewLists from './useOverviewLists'
 
 const OverviewDetails = () => {
-    const { lists, isLoading } = useGetCorrectlyOrderedOverviewLists()
+    const { lists, isLoading } = useOverviewLists()
     const { overviewViewId, overviewItemId, subtaskId } = useParams()
     const selectedList = lists?.find((list) => list.id === overviewViewId)
     const selectedItem = selectedList?.view_items.find((item) => item.id === overviewItemId)

--- a/frontend/src/components/overview/useOverviewLists.ts
+++ b/frontend/src/components/overview/useOverviewLists.ts
@@ -1,6 +1,6 @@
 import { useCallback, useMemo } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { useItemSelectionController } from '../../hooks'
+import { useGTLocalStorage, useItemSelectionController } from '../../hooks'
 import Log from '../../services/api/log'
 import { useGetOverviewViews } from '../../services/api/overview.hooks'
 import { useGetSettings } from '../../services/api/settings.hooks'
@@ -16,6 +16,7 @@ type TOverviewItemWithListId = TOverviewItem & { listId: string }
 const useOverviewLists = () => {
     const { data: lists, isLoading: areListsLoading } = useGetOverviewViews()
     const { data: settings, isLoading: areSettingsLoading } = useGetSettings()
+    const [overviewAutomaticEmptySort] = useGTLocalStorage('overviewAutomaticEmptySort', false, true)
     const navigate = useNavigate()
 
     const sortedAndFilteredLists = useMemo(() => {
@@ -66,6 +67,15 @@ const useOverviewLists = () => {
     }, [])
     useItemSelectionController(flattenedLists, selectItem)
 
+    if (overviewAutomaticEmptySort) {
+        const copy = [...sortedAndFilteredLists]
+        copy.sort((a, b) => {
+            if (a.view_items.length === 0 && b.view_items.length > 0) return 1
+            if (a.view_items.length > 0 && b.view_items.length === 0) return -1
+            return 0
+        })
+        return { lists: copy, isLoading: areListsLoading }
+    }
     return { lists: sortedAndFilteredLists, isLoading: areListsLoading }
 }
 

--- a/frontend/src/components/views/DailyOverviewView.tsx
+++ b/frontend/src/components/views/DailyOverviewView.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useLayoutEffect, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import styled from 'styled-components'
-import { useGTLocalStorage } from '../../hooks'
 import { Border, Colors, Spacing, Typography } from '../../styles'
 import { icons } from '../../styles/images'
 import Flex from '../atoms/Flex'
@@ -32,21 +31,6 @@ const RightActions = styled.div`
     display: flex;
 `
 
-export const useGetCorrectlyOrderedOverviewLists = () => {
-    const { lists, isLoading } = useOverviewLists()
-    const [overviewAutomaticEmptySort] = useGTLocalStorage('overviewAutomaticEmptySort', false, true)
-    if (overviewAutomaticEmptySort) {
-        const listsCopy = [...lists]
-        listsCopy.sort((a, b) => {
-            if (a.view_items.length === 0 && b.view_items.length > 0) return 1
-            if (a.view_items.length > 0 && b.view_items.length === 0) return -1
-            return 0
-        })
-        return { lists: listsCopy, isLoading }
-    }
-    return { lists, isLoading }
-}
-
 const DailyOverviewView = () => {
     const [isEditListsModalOpen, setIsEditListsModalOpen] = useState(false)
     const [editListTabIndex, setEditListTabIndex] = useState(0) // 0 - add, 1 - reorder
@@ -58,7 +42,7 @@ const DailyOverviewView = () => {
     const expandAll = () => setOpenListIds(lists.map((list) => list.id))
     const collapseAll = () => setOpenListIds([])
 
-    const { lists, isLoading } = useGetCorrectlyOrderedOverviewLists()
+    const { lists, isLoading } = useOverviewLists()
     useLayoutEffect(() => {
         if (overviewViewId && overviewItemId) {
             setOpenListIds((ids) => {


### PR DESCRIPTION
One weird thing is that we need to make a copy of the list in order to sort it, we do this because we need to keep track of the original list ordering 