### PR TITLE
Fall back to calendar color id for event popover

### DIFF
--- a/frontend/src/components/radix/EventDetailPopover.tsx
+++ b/frontend/src/components/radix/EventDetailPopover.tsx
@@ -122,7 +122,7 @@ const EventDetailPopover = ({ event, date, hidePopover = false, children }: Even
             <EventTitle>{event.title}</EventTitle>
             {isPreviewMode && calendarAccount && calendar && (
                 <Flex gap={Spacing._8}>
-                    <Icon icon={icons.square} colorHex={getCalendarColor(event.color_id)} />
+                    <Icon icon={icons.square} colorHex={getCalendarColor(event.color_id || calendar.color_id)} />
                     <Label>
                         {calendar.title} ({calendarAccount.account_id})
                     </Label>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/42781446/216170179-94cb0a2a-602b-4405-a4a5-02040d0211e2.png)

`event.color_id` only gets populated if the event color was manually overridden, so we fall back to the calendar color id
