### PR TITLE
Fix optimistic updates for subtasks

### DIFF
--- a/frontend/src/services/api/tasks.hooks.ts
+++ b/frontend/src/services/api/tasks.hooks.ts
@@ -344,7 +344,7 @@ export const useModifyTask = () => {
             const sections = queryClient.getImmutableQueryData<TTaskSection[]>('tasks')
             if (sections) {
                 const newSections = produce(sections, (draft) => {
-                    const task = getTaskFromSections(draft, data.id, data.subtaskId)
+                    const task = getTaskFromSections(draft, data.id, undefined, data.subtaskId)
                     if (!task) return
                     modifyTaskOptimisticUpdate(task, data)
                 })


### PR DESCRIPTION
`getTaskFromSections` was failing to find the subtask, because we were passing in `subtaskId` as `sectionId` so it was just returning undefined. 