### PR TITLE
Modularize timeout logic for notes

### DIFF
--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -1,5 +1,6 @@
 import useAuthWindow from './useAuthWindow'
 import useClickOutside from './useClickOutside'
+import useDebouncedEdit from './useDebouncedEdit'
 import useEventBanners from './useEventBanners'
 import useGTLocalStorage from './useGTLocalStorage'
 import useGlobalKeyboardShortcuts from './useGlobalKeyboardShortcuts'
@@ -32,4 +33,5 @@ export {
     useToast,
     usePageFocus,
     useWindowSize,
+    useDebouncedEdit,
 }

--- a/frontend/src/hooks/useDebouncedEdit.ts
+++ b/frontend/src/hooks/useDebouncedEdit.ts
@@ -1,0 +1,61 @@
+import { useEffect, useRef, useState } from 'react'
+import { NO_TITLE, SYNC_MESSAGES } from '../constants'
+
+export interface TSaveData {
+    onSave: (data: TModifyData) => void
+    isError: boolean
+    isLoading: boolean
+}
+
+export interface TModifyData {
+    id: string
+    title?: string
+    body?: string
+}
+
+const useDebouncedEdit = ({ onSave, isError, isLoading }: TSaveData, delay: number) => {
+    const timers = useRef<{ [key: string]: { timeout: NodeJS.Timeout; callback: () => void } }>({})
+    const [syncIndicatorText, setSyncIndicatorText] = useState(SYNC_MESSAGES.COMPLETE)
+    const [isEditing, setIsEditing] = useState(false)
+
+    const sync = ({ id, title, body }: TModifyData) => {
+        setIsEditing(false)
+        const timerId = id + (title === undefined ? 'body' : 'title')
+        if (title === '') title = NO_TITLE
+        if (timers.current[timerId]) clearTimeout(timers.current[timerId].timeout)
+        onSave({ id, title, body })
+    }
+
+    const onEdit = ({ id, title, body }: TModifyData) => {
+        setIsEditing(true)
+        const timerId = id + (title === undefined ? 'body' : 'title')
+        if (timers.current[timerId]) clearTimeout(timers.current[timerId].timeout)
+        timers.current[timerId] = {
+            timeout: setTimeout(() => sync({ id, title, body }), delay),
+            callback: () => sync({ id, title, body }),
+        }
+    }
+
+    useEffect(() => {
+        return () => {
+            for (const timer of Object.values(timers.current)) {
+                timer.callback()
+                clearTimeout(timer.timeout)
+            }
+        }
+    }, [])
+
+    useEffect(() => {
+        if (isEditing || isLoading) {
+            setSyncIndicatorText(SYNC_MESSAGES.SYNCING)
+        } else if (isError) {
+            setSyncIndicatorText(SYNC_MESSAGES.ERROR)
+        } else {
+            setSyncIndicatorText(SYNC_MESSAGES.COMPLETE)
+        }
+    }, [isError, isLoading, isEditing])
+
+    return { onEdit, isEditing, syncIndicatorText }
+}
+
+export default useDebouncedEdit


### PR DESCRIPTION
We can apply this logic to the note create modal as well as the task details, but there is some additional work to do for both of those.

For the task details, we have to handle modifying recurring task templates + normal tasks at the same time as well as optimistic ids.

For the note create modal, we have to handle optimistic creation which took a lot of custom logic to get to work as well as modifying shared_until along with everything else.

I would prefer to handle those in a separate PR as to not mess with this existing code, which works.