### PR TITLE
add HasAnyCalendarScope field to /calendars endpoint

### DIFF
--- a/backend/api/calendar_list.go
+++ b/backend/api/calendar_list.go
@@ -18,10 +18,10 @@ type CalendarResult struct {
 }
 
 type CalendarAccountResult struct {
-	AccountID           string           `json:"account_id"`
-	Calendars           []CalendarResult `json:"calendars"`
-	HasMulticalScope    bool             `json:"has_multical_scopes"`
-	HasAnyCalendarScope bool             `json:"has_any_calendar_scope"`
+	AccountID               string           `json:"account_id"`
+	Calendars               []CalendarResult `json:"calendars"`
+	HasMulticalScope        bool             `json:"has_multical_scopes"`
+	HasPrimaryCalendarScope bool             `json:"has_primary_calendar_scopes"`
 }
 
 func (api *API) CalendarsList(c *gin.Context) {
@@ -55,10 +55,10 @@ func (api *API) CalendarsList(c *gin.Context) {
 
 		}
 		result := CalendarAccountResult{
-			AccountID:           account.IDExternal,
-			Calendars:           calendars,
-			HasMulticalScope:    database.HasUserGrantedMultiCalendarScope(account.Scopes),
-			HasAnyCalendarScope: database.HasUserGrantedCalendarScope(account.Scopes),
+			AccountID:               account.IDExternal,
+			Calendars:               calendars,
+			HasMulticalScope:        database.HasUserGrantedMultiCalendarScope(account.Scopes),
+			HasPrimaryCalendarScope: database.HasUserGrantedPrimaryCalendarScope(account.Scopes),
 		}
 		results = append(results, &result)
 	}

--- a/backend/api/calendar_list_test.go
+++ b/backend/api/calendar_list_test.go
@@ -118,9 +118,9 @@ func TestCalendarList(t *testing.T) {
 		assert.Equal(t, 3, len(result))
 
 		assert.Equal(t, []CalendarAccountResult{
-			{AccountID: "360-no-scope", Calendars: []CalendarResult{{CalendarID: "cal1", ColorID: "col1", Title: "title1", CanWrite: true}}, HasMulticalScope: false, HasAnyCalendarScope: false},
-			{AccountID: "account2", Calendars: []CalendarResult{{CalendarID: "cal2", ColorID: "col2", Title: "title2", CanWrite: false}, {CalendarID: "cal3", ColorID: "col3", Title: "title3", CanWrite: true}}, HasMulticalScope: true, HasAnyCalendarScope: true},
-			{AccountID: "single-cal", Calendars: []CalendarResult{{CalendarID: "cal2", ColorID: "col2", Title: "title2", CanWrite: false}}, HasMulticalScope: false, HasAnyCalendarScope: true},
+			{AccountID: "360-no-scope", Calendars: []CalendarResult{{CalendarID: "cal1", ColorID: "col1", Title: "title1", CanWrite: true}}, HasMulticalScope: false, HasPrimaryCalendarScope: false},
+			{AccountID: "account2", Calendars: []CalendarResult{{CalendarID: "cal2", ColorID: "col2", Title: "title2", CanWrite: false}, {CalendarID: "cal3", ColorID: "col3", Title: "title3", CanWrite: true}}, HasMulticalScope: true, HasPrimaryCalendarScope: false},
+			{AccountID: "single-cal", Calendars: []CalendarResult{{CalendarID: "cal2", ColorID: "col2", Title: "title2", CanWrite: false}}, HasMulticalScope: false, HasPrimaryCalendarScope: true},
 		},
 			result)
 	})

--- a/backend/database/helpers.go
+++ b/backend/database/helpers.go
@@ -1007,6 +1007,6 @@ func HasUserGrantedMultiCalendarScope(scopes []string) bool {
 	return slices.Contains(scopes, "https://www.googleapis.com/auth/calendar")
 }
 
-func HasUserGrantedCalendarScope(scopes []string) bool {
-	return slices.Contains(scopes, "https://www.googleapis.com/auth/calendar.events") || slices.Contains(scopes, "https://www.googleapis.com/auth/calendar")
+func HasUserGrantedPrimaryCalendarScope(scopes []string) bool {
+	return slices.Contains(scopes, "https://www.googleapis.com/auth/calendar.events")
 }


### PR DESCRIPTION
indicates if a calendar has either single or multi cal scopes. 

maybe this should just be `HasSingleCalScope`?