### PR TITLE
Allow ingress from notes subdomain also

### DIFF
--- a/kubernetes/manifests/prod/prd-application-ingress-ssl-notes.yaml
+++ b/kubernetes/manifests/prod/prd-application-ingress-ssl-notes.yaml
@@ -1,0 +1,38 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: "core-ingress"
+  namespace: "prd-gtsk-uswest1"
+  annotations:
+    kubernetes.io/ingress.class: alb
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    # Health Check Settings
+    alb.ingress.kubernetes.io/healthcheck-protocol: HTTP
+    alb.ingress.kubernetes.io/healthcheck-port: traffic-port
+    alb.ingress.kubernetes.io/tags: Name=prd-gtask-uswest1-alb,Environment=PRD
+    #Important Note:  Need to add health check path annotations in service level if we are planning to use multiple targets in a load balancer
+    alb.ingress.kubernetes.io/healthcheck-path: /ping/
+    alb.ingress.kubernetes.io/healthcheck-interval-seconds: '15'
+    alb.ingress.kubernetes.io/healthcheck-timeout-seconds: '5'
+    alb.ingress.kubernetes.io/success-codes: '200'
+    alb.ingress.kubernetes.io/healthy-threshold-count: '2'
+    alb.ingress.kubernetes.io/unhealthy-threshold-count: '2'
+    ## SSL Settings
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
+    alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:us-west-1:257821106339:certificate/553eefd8-86da-42c6-ab5c-ad8556b5c9d6
+    # SSL Redirect Setting
+    # alb.ingress.kubernetes.io/actions.ssl-redirect: '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}'
+    external-dns.alpha.kubernetes.io/hostname: notes.generaltask.com
+
+spec:
+  rules:
+  - host: "notes.generaltask.com"
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: core-service
+            port:
+              number: 8080


### PR DESCRIPTION
Want to allow the link we have for people be `notes.generaltask.com` which surfaces our API server, which surfaces the metadata, and then we redirect to the frontend notes page.

Not sure the best way to test this - would love any guidance @alfaindia 