### PR TITLE
Add recurring task filtering setting

### DIFF
--- a/backend/settings/main.go
+++ b/backend/settings/main.go
@@ -65,6 +65,8 @@ const (
 	SettingFieldNoteFilteringPreference = "note_filtering_preference"
 	ChoiceKeyNoDeleted                  = "no_deleted"
 	ChoiceKeyShowDeleted                = "show_deleted"
+	// Recurring task filtering
+	SettingFieldRecurringTaskFilteringPreference = "recurring_task_filtering_preference"
 	// Calendar choice
 	SettingFieldCalendarForNewTasks   = "calendar_account_id_for_new_tasks"
 	SettingFieldCalendarIDForNewTasks = "calendar_calendar_id_for_new_tasks"
@@ -191,6 +193,15 @@ var NoteFilteringSetting = SettingDefinition{
 	},
 }
 
+var RecurringTaskFilteringSetting = SettingDefinition{
+	FieldKey:      SettingFieldRecurringTaskFilteringPreference,
+	DefaultChoice: ChoiceKeyNoDeleted,
+	Choices: []SettingChoice{
+		{Key: ChoiceKeyNoDeleted},
+		{Key: ChoiceKeyShowDeleted},
+	},
+}
+
 var OverviewCollapseEmptyListsSetting = SettingDefinition{
 	FieldKey:      SettingCollapseEmptyLists,
 	DefaultChoice: "true",
@@ -230,22 +241,27 @@ var HasDismissedMulticalPromptSetting = SettingDefinition{
 var TaskSectionSettingTypes = []string{"main", "overview"}
 
 var hardcodedSettings = []SettingDefinition{
-	// these settings are for the Github PR page
+	// Github PR page settings
 	GithubFilteringSetting,
 	GithubSortingPreferenceSetting,
 	GithubSortingDirectionSetting,
-	// these settings are for the sidebar
+	// sidebar settings
 	SidebarLinearSetting,
 	SidebarJiraSetting,
 	SidebarGithubSetting,
 	SidebarSlackSetting,
-	// these settings are for the notes page
+	// notes page settings
 	NoteSortingPreferenceSetting,
 	NoteSortingDirectionSetting,
 	NoteFilteringSetting,
+	// recurring tasks page settings
+	RecurringTaskFilteringSetting,
+	// overview settings
 	OverviewCollapseEmptyListsSetting,
 	OverviewMoveEmptyListsToBottomSetting,
+	// smart prioritize settings
 	LabSmartPrioritizeEnabledSetting,
+	// multical settings
 	HasDismissedMulticalPromptSetting,
 }
 

--- a/backend/settings/main_test.go
+++ b/backend/settings/main_test.go
@@ -102,7 +102,7 @@ func TestGetSettingsOptions(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		settings, err := GetSettingsOptions(db, userID)
 		assert.NoError(t, err)
-		assert.Equal(t, 27, len(*settings))
+		assert.Equal(t, 28, len(*settings))
 		assert.Equal(t, "sidebar_linear_preference", (*settings)[3].FieldKey)
 		assert.Equal(t, "sidebar_jira_preference", (*settings)[4].FieldKey)
 		assert.Equal(t, "sidebar_github_preference", (*settings)[5].FieldKey)
@@ -110,29 +110,30 @@ func TestGetSettingsOptions(t *testing.T) {
 		assert.Equal(t, "note_sorting_preference", (*settings)[7].FieldKey)
 		assert.Equal(t, "note_sorting_direction", (*settings)[8].FieldKey)
 		assert.Equal(t, "note_filtering_preference", (*settings)[9].FieldKey)
-		assert.Equal(t, "collapse_empty_lists", (*settings)[10].FieldKey)
-		assert.Equal(t, "move_empty_lists_to_bottom", (*settings)[11].FieldKey)
-		assert.Equal(t, "lab_smart_prioritize_enabled", (*settings)[12].FieldKey)
-		assert.Equal(t, "has_dismissed_multical_prompt", (*settings)[13].FieldKey)
-		assert.Equal(t, insertedViewID+"_github_filtering_preference", (*settings)[14].FieldKey)
-		assert.Equal(t, insertedViewID+"_github_sorting_preference", (*settings)[15].FieldKey)
-		assert.Equal(t, insertedViewID+"_github_sorting_direction", (*settings)[16].FieldKey)
-		assert.Equal(t, insertedSectionID+"_task_sorting_preference_main", (*settings)[17].FieldKey)
-		assert.Equal(t, insertedSectionID+"_task_sorting_direction_main", (*settings)[18].FieldKey)
-		assert.Equal(t, insertedSectionID+"_task_sorting_preference_overview", (*settings)[19].FieldKey)
-		assert.Equal(t, insertedSectionID+"_task_sorting_direction_overview", (*settings)[20].FieldKey)
-		assert.Equal(t, "000000000000000000000001_task_sorting_preference_main", (*settings)[21].FieldKey)
-		assert.Equal(t, "000000000000000000000001_task_sorting_direction_main", (*settings)[22].FieldKey)
-		assert.Equal(t, "000000000000000000000001_task_sorting_preference_overview", (*settings)[23].FieldKey)
-		assert.Equal(t, "000000000000000000000001_task_sorting_direction_overview", (*settings)[24].FieldKey)
-		calendarSetting := (*settings)[25]
+		assert.Equal(t, "recurring_task_filtering_preference", (*settings)[10].FieldKey)
+		assert.Equal(t, "collapse_empty_lists", (*settings)[11].FieldKey)
+		assert.Equal(t, "move_empty_lists_to_bottom", (*settings)[12].FieldKey)
+		assert.Equal(t, "lab_smart_prioritize_enabled", (*settings)[13].FieldKey)
+		assert.Equal(t, "has_dismissed_multical_prompt", (*settings)[14].FieldKey)
+		assert.Equal(t, insertedViewID+"_github_filtering_preference", (*settings)[15].FieldKey)
+		assert.Equal(t, insertedViewID+"_github_sorting_preference", (*settings)[16].FieldKey)
+		assert.Equal(t, insertedViewID+"_github_sorting_direction", (*settings)[17].FieldKey)
+		assert.Equal(t, insertedSectionID+"_task_sorting_preference_main", (*settings)[18].FieldKey)
+		assert.Equal(t, insertedSectionID+"_task_sorting_direction_main", (*settings)[19].FieldKey)
+		assert.Equal(t, insertedSectionID+"_task_sorting_preference_overview", (*settings)[20].FieldKey)
+		assert.Equal(t, insertedSectionID+"_task_sorting_direction_overview", (*settings)[21].FieldKey)
+		assert.Equal(t, "000000000000000000000001_task_sorting_preference_main", (*settings)[22].FieldKey)
+		assert.Equal(t, "000000000000000000000001_task_sorting_direction_main", (*settings)[23].FieldKey)
+		assert.Equal(t, "000000000000000000000001_task_sorting_preference_overview", (*settings)[24].FieldKey)
+		assert.Equal(t, "000000000000000000000001_task_sorting_direction_overview", (*settings)[25].FieldKey)
+		calendarSetting := (*settings)[26]
 		assert.Equal(t, SettingFieldCalendarForNewTasks, calendarSetting.FieldKey)
 		assert.Equal(t, "a", calendarSetting.DefaultChoice)
 		assert.Equal(t, []SettingChoice{
 			{Key: "a", Name: "oof 1"},
 			{Key: "b", Name: "oof 2"},
 		}, calendarSetting.Choices)
-		calendarIDSetting := (*settings)[26]
+		calendarIDSetting := (*settings)[27]
 		assert.Equal(t, SettingFieldCalendarIDForNewTasks, calendarIDSetting.FieldKey)
 		assert.Equal(t, []SettingChoice{
 			{Key: "cal1", Name: "title1"},


### PR DESCRIPTION
Add filtering functionality to recurring tasks page. This will be followed up by:

- Frontend PR to get the setting from the backend
- Frontend PR to make use of the setting to filter out deleted recurring tasks (feature locked)
- Backend PR to enable sending of recurring tasks with the `is_deleted: true` to the frontend