### PR TITLE
Don't show duplicate calendar id  in event detail popover

### DIFF
--- a/frontend/src/components/radix/EventDetailPopover.tsx
+++ b/frontend/src/components/radix/EventDetailPopover.tsx
@@ -124,7 +124,7 @@ const EventDetailPopover = ({ event, date, hidePopover = false, children }: Even
                 <Flex gap={Spacing._8}>
                     <Icon icon={icons.square} colorHex={getCalendarColor(event.color_id || calendar.color_id)} />
                     <Label>
-                        {calendar.title
+                        {calendar.title && calendar.title !== calendarAccount.account_id
                             ? `${calendar.title} (${calendarAccount.account_id})`
                             : calendarAccount.account_id}
                     </Label>


### PR DESCRIPTION
Before:
<img width="337" alt="image" src="https://user-images.githubusercontent.com/42781446/217080247-50a916a8-6928-4faf-af93-57f3ff229670.png">

After:
<img width="357" alt="image" src="https://user-images.githubusercontent.com/42781446/217080142-4234719d-7a23-4d66-b9f8-219c677aa348.png">
