### PR TITLE
Reduce size of google auth button

### DIFF
--- a/frontend/src/components/screens/GoogleAuthScreen.tsx
+++ b/frontend/src/components/screens/GoogleAuthScreen.tsx
@@ -12,7 +12,6 @@ const Container = styled.div`
 `
 const Link = styled.a`
     width: 200px;
-    max-width: 30vw;
 `
 
 const GoogleAuthScreen = () => {


### PR DESCRIPTION
per [john's request](https://github.com/GeneralTask/task-manager/pull/2931/#issuecomment-1416562293)

<img width="1496" alt="image" src="https://user-images.githubusercontent.com/42781446/217133987-474a563a-b72b-4ff8-acbf-2588e826c049.png">
