### PR TITLE
Use calendar color id when optimistically creating events

### DIFF
--- a/frontend/src/services/api/events.hooks.ts
+++ b/frontend/src/services/api/events.hooks.ts
@@ -138,7 +138,7 @@ export const useCreateEvent = () => {
                 body: createEventPayload.description ?? '',
                 account_id: createEventPayload.account_id,
                 calendar_id: createEventPayload.calendar_id ?? calendar?.calendar_id ?? '',
-                color_id: calendar?.color_id ?? '',
+                color_id: '',
                 logo: linkedTask?.source.logo_v2 ?? 'gcal',
                 deeplink: '',
                 datetime_start: createEventPayload.datetime_start,


### PR DESCRIPTION
previously the color would flicker because we were trying to set the color ID, but the backend actually always sends an empty string in color_id and we instead fall back to the calendar color_id. so this makes the optimistic creation better match the backend response

Before:

https://user-images.githubusercontent.com/42781446/217301083-48bab2b1-8829-4f62-a439-d32d27d3c56c.mov


After:

https://user-images.githubusercontent.com/42781446/217300432-e2162ef5-7204-4e02-8283-a40e299b1df7.mov

