### PR TITLE
Remove linear specific duedate logic

### DIFF
--- a/frontend/src/components/details/TaskDetails.tsx
+++ b/frontend/src/components/details/TaskDetails.tsx
@@ -353,7 +353,6 @@ const TaskDetails = ({ task, subtask, isRecurringTaskTemplate }: TaskDetailsProp
                         initialDate={DateTime.fromISO(currentTask.due_date ?? '')}
                         setDate={(date) => modifyTask({ id: task.id, dueDate: date, subtaskId: subtask?.id })}
                         disabled={isInTrash}
-                        isLinearTask={task.source?.name === 'Linear'}
                     />
                 )}
                 {isRecurringTaskTemplate ? (

--- a/frontend/src/components/molecules/GTDatePicker.tsx
+++ b/frontend/src/components/molecules/GTDatePicker.tsx
@@ -44,14 +44,7 @@ interface GTDatePickerProps {
     disabled?: boolean
     isLinearTask?: boolean
 }
-const GTDatePicker = ({
-    initialDate,
-    setDate,
-    showIcon = true,
-    onlyCalendar = false,
-    disabled,
-    isLinearTask = false,
-}: GTDatePickerProps) => {
+const GTDatePicker = ({ initialDate, setDate, showIcon = true, onlyCalendar = false, disabled }: GTDatePickerProps) => {
     const [currentDate, setCurrentDate] = useState<DateTime | null>(initialDate)
     const [isOpen, setIsOpen] = useState(false)
 
@@ -69,16 +62,7 @@ const GTDatePicker = ({
             setDate(DateTime.fromMillis(0).toISO())
         } else {
             setCurrentDate(DateTime.fromJSDate(date))
-            if (isLinearTask) {
-                const datetimeUTCMidnight = DateTime.utc(
-                    date.getFullYear(),
-                    date.getMonth() + 1,
-                    date.getDate()
-                ).startOf('day')
-                setDate(datetimeUTCMidnight.toISO())
-            } else {
-                setDate(DateTime.fromJSDate(date).toISO())
-            }
+            setDate(DateTime.fromJSDate(date).toISO())
         }
     }
 

--- a/frontend/src/components/radix/TaskContextMenuWrapper.tsx
+++ b/frontend/src/components/radix/TaskContextMenuWrapper.tsx
@@ -102,7 +102,6 @@ const TaskContextMenuWrapper = ({ task, sectionId, parentTask, children, onOpenC
                                 }
                             }}
                             onlyCalendar
-                            isLinearTask={task.source?.name === 'Linear'}
                         />
                     ),
                 },


### PR DESCRIPTION
Now that we're using a new `due_date` format, we don't need to have Linear-specific date logic on the frontend