### PR TITLE
Fix bug that caused new linear issues to not show up in overview page

### DIFF
--- a/backend/api/linear_webhook.go
+++ b/backend/api/linear_webhook.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/GeneralTask/task-manager/backend/constants"
 	"github.com/GeneralTask/task-manager/backend/database"
 	"github.com/GeneralTask/task-manager/backend/external"
 	"github.com/GeneralTask/task-manager/backend/logging"
@@ -365,6 +366,7 @@ func populateLinearTask(userID primitive.ObjectID, accountID string, webhookPayl
 		UserID:             userID,
 		IDExternal:         issuePayload.ID,
 		Deeplink:           webhookPayload.Url,
+		IDTaskSection:      constants.IDTaskSectionDefault,
 		SourceID:           external.TASK_SOURCE_ID_LINEAR,
 		Title:              &issuePayload.Title,
 		Body:               &issuePayload.Description,


### PR DESCRIPTION
The reason new linear issues weren't showing up in the overview page is because the issues weren't being assigned an id section. We use the id section field to populate lists in the overview page