### PR TITLE
Hide calendar when clicking nav items (when task to cal sidebar isn't open)

### DIFF
--- a/frontend/src/components/navigation_sidebar/NavigationLink.tsx
+++ b/frontend/src/components/navigation_sidebar/NavigationLink.tsx
@@ -100,7 +100,7 @@ const NavigationLink = ({
 }: NavigationLinkProps) => {
     const { mutate: reorderTask } = useReorderTask()
     const { mutate: markTaskDoneOrDeleted } = useMarkTaskDoneOrDeleted()
-    const { setCalendarType, setDate, dayViewDate } = useCalendarContext()
+    const { setCalendarType, setDate, dayViewDate, showTaskToCalSidebar } = useCalendarContext()
     const navigate = useNavigate()
     const { isPreviewMode } = usePreviewMode()
 
@@ -155,7 +155,7 @@ const NavigationLink = ({
 
     const onClickHandler = (e: React.MouseEvent<HTMLDivElement | HTMLButtonElement>) => {
         if (taskSection?.id === TASK_SECTION_DEFAULT_ID) e.preventDefault()
-        if (!isPreviewMode) {
+        if (!isPreviewMode || !showTaskToCalSidebar) {
             setCalendarType('day')
             setDate(dayViewDate)
         }


### PR DESCRIPTION
Previously (in preview mode) the calendar would never hide when clicking nav items. Now it does. This is just a minor improvement to task-to-cal functionality.

https://user-images.githubusercontent.com/31417618/217388150-c2ffc49d-f0c0-4ba0-be73-31c7a67eba44.mov

