### PR TITLE
Don't show empty/complete status label before loading list items

### DIFF
--- a/frontend/src/services/api/overview.hooks.ts
+++ b/frontend/src/services/api/overview.hooks.ts
@@ -184,7 +184,7 @@ export const useAddView = () => {
                             view_items: [],
                             sources: [],
                             is_linked: true,
-                            has_tasks_completed_today: undefined,
+                            has_tasks_completed_today: false,
                         }
                         draft.push(optimisticView)
                     })

--- a/frontend/src/utils/types.ts
+++ b/frontend/src/utils/types.ts
@@ -308,7 +308,7 @@ export interface TOverviewView {
     total_view_items?: number // the total number of items in the view without filters applied
     sources: TSourcesResult[]
     is_linked: boolean
-    has_tasks_completed_today?: boolean
+    has_tasks_completed_today: boolean
 }
 
 export interface TSupportedViewItem {


### PR DESCRIPTION
We don't want to show a label because we don't know if the message should be `List complete ` or `Empty`

https://user-images.githubusercontent.com/9156543/217430219-f96fa5f6-5e64-49d8-bb7f-5c8ca5eef9cb.mov

