### PR TITLE
Convert  ADF mediaSingle images to markdown

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -65,7 +65,6 @@
     "@sentry/react": "^7.7.0",
     "@sentry/tracing": "^7.7.0",
     "@sentry/types": "^7.7.0",
-    "adf-to-md": "^2.0.0",
     "animate.css": "^4.1.1",
     "assert": "^2.0.0",
     "axios": "^0.26.1",

--- a/frontend/src/components/atoms/GTTextField/AtlassianEditor/Editor.tsx
+++ b/frontend/src/components/atoms/GTTextField/AtlassianEditor/Editor.tsx
@@ -1,11 +1,11 @@
 import { Editor as AtlaskitEditor, EditorActions } from '@atlaskit/editor-core'
 import { JSONTransformer } from '@atlaskit/editor-json-transformer'
 import { MarkdownTransformer } from '@atlaskit/editor-markdown-transformer'
-import adf2md from 'adf-to-md'
 import styled from 'styled-components'
 import { Spacing } from '../../../../styles'
 import { TOOLBAR_HEIGHT } from '../toolbar/styles'
 import { RichTextEditorProps } from '../types'
+import adf2md from './adfToMd'
 
 const serializer = new JSONTransformer()
 

--- a/frontend/src/components/atoms/GTTextField/AtlassianEditor/adf-to-md.ts
+++ b/frontend/src/components/atoms/GTTextField/AtlassianEditor/adf-to-md.ts
@@ -1,7 +1,0 @@
-// https://github.com/julianlam/adf-to-md
-declare module 'adf-to-md' {
-    function convert(adf: object): {
-        result: string
-        warnings: string[]
-    }
-}

--- a/frontend/src/components/atoms/GTTextField/AtlassianEditor/adfToMd.js
+++ b/frontend/src/components/atoms/GTTextField/AtlassianEditor/adfToMd.js
@@ -1,0 +1,145 @@
+/* eslint-disable no-console */
+
+/* eslint-disable no-prototype-builtins */
+import * as Sentry from '@sentry/browser'
+
+// copied from https://github.com/julianlam/adf-to-md, modified to add support for more node types
+
+function _convert(node, warnings) {
+    switch (node.type) {
+        case 'doc':
+            return node.content.map((node) => _convert(node, warnings)).join('\n\n')
+
+        case 'text':
+            return `${_convertMarks(node, warnings)}`
+
+        case 'paragraph':
+            return node.content.map((node) => _convert(node, warnings)).join('')
+
+        case 'heading':
+            return `${'#'.repeat(node.attrs.level)} ${node.content.map((node) => _convert(node, warnings)).join('')}`
+
+        case 'hardBreak':
+            return '\n'
+
+        case 'blockquote':
+            return `> ${node.content.map((node) => _convert(node, warnings)).join('\n> ')}`
+
+        case 'bulletList':
+        case 'orderedList':
+            return `${node.content
+                .map((subNode) => {
+                    const converted = _convert.call(node, subNode, warnings)
+                    if (node.type === 'orderedList') {
+                        if (!node.attrs) {
+                            node.attrs = {
+                                order: 1,
+                            }
+                        }
+                        node.attrs.order += 1
+                    }
+                    return converted
+                })
+                .join('\n')}`
+
+        case 'listItem': {
+            const order = this.attrs ? this.attrs.order || 1 : 1
+            const symbol = this.type === 'bulletList' ? '*' : `${order}.`
+            return `  ${symbol} ${node.content.map((node) => _convert(node, warnings).trimEnd()).join(` `)}`
+        }
+
+        case 'codeBlock': {
+            const language = node.attrs ? ` ${node.attrs.language}` : ''
+            return `\`\`\`${language}\n${node.content.map((node) => _convert(node, warnings)).join('\n')}\n\`\`\``
+        }
+
+        // added to existing source code
+        case 'mediaSingle': {
+            if (node?.content?.[0]?.attrs?.url) {
+                return `![](${node.content[0].attrs.url})`
+            } else {
+                Sentry.captureMessage(
+                    `failed to convert unsupported mediaSingle node to markdown: ${JSON.stringify(node)}`
+                )
+                break
+            }
+        }
+
+        default:
+            console.log('adding warning for', node.type)
+            warnings.add(node.type)
+            return ''
+    }
+}
+
+function _convertMarks(node, warnings) {
+    if (!node.hasOwnProperty('marks') || !Array.isArray(node.marks)) {
+        return node.text
+    }
+
+    return node.marks.reduce((converted, mark) => {
+        switch (mark.type) {
+            case 'code':
+                converted = `\`${converted}\``
+                break
+
+            case 'em':
+                converted = `_${converted}_`
+                break
+
+            case 'link':
+                converted = `[${converted}](${mark.attrs.href})`
+                break
+
+            case 'strike':
+                converted = `~${converted}~`
+                break
+
+            case 'strong':
+                converted = `**${converted}**`
+                break
+
+            default: // not supported
+                warnings.add(mark.type)
+                break
+        }
+
+        return converted
+    }, node.text)
+}
+
+const convert = (adf) => {
+    const warnings = new Set()
+
+    validate(adf)
+
+    // todo: do stuff with warnings
+
+    return {
+        result: _convert(adf, warnings),
+        warnings,
+    }
+}
+
+const validate = (adf) => {
+    // Super naive validation -- someday validate against this: https://unpkg.com/@atlaskit/adf-schema@22.0.1/dist/json-schema/v1/full.json
+    let ok = true
+
+    if (!adf || typeof adf !== 'object') {
+        ok = false
+    }
+
+    if (adf.type !== 'doc') {
+        ok = false
+    }
+
+    if (adf.version !== 1) {
+        ok = false
+    }
+
+    if (!ok) {
+        throw new Error('adf-validation-failed')
+    }
+}
+
+export default { convert, validate }

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -6393,13 +6393,6 @@ acorn@^8.2.4, acorn@^8.5.0, acorn@^8.7.1, acorn@^8.8.0:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.8.1.tgz#0a3f9cbecc4ec3bea6f0a80b66ae8dd2da250b73"
   integrity sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==
 
-adf-to-md@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/adf-to-md/-/adf-to-md-2.0.0.tgz#d2af5667eb0cd403180453af25d4f59415de5cb1"
-  integrity sha512-u4syjIIHl+LLHSX8am1GNpf3tNa06FD3T6EjD+teUceg4xwRrfKa/WB3FBGy5qw9VfkYNBn2tu8tXgKVkJbRaQ==
-  dependencies:
-    eslint-config-nodebb "0.1.1"
-
 agent-base@6:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"
@@ -7517,11 +7510,6 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
 
-confusing-browser-globals@^1.0.10:
-  version "1.0.11"
-  resolved "https://registry.yarnpkg.com/confusing-browser-globals/-/confusing-browser-globals-1.0.11.tgz#ae40e9b57cdd3915408a2805ebd3a5585608dc81"
-  integrity sha512-JsPKdmh8ZkmnHxDk55FZ1TqVLvEQTvoByJZRN9jzI0UjxK/QgAmsphz7PGtqgPieQZ/CQcHWXCR7ATDNhGe+YA==
-
 connect-history-api-fallback@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/connect-history-api-fallback/-/connect-history-api-fallback-2.0.0.tgz#647264845251a0daf25b97ce87834cace0f5f1c8"
@@ -8326,23 +8314,6 @@ escodegen@^2.0.0:
     optionator "^0.8.1"
   optionalDependencies:
     source-map "~0.6.1"
-
-eslint-config-airbnb-base@15.0.0:
-  version "15.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-airbnb-base/-/eslint-config-airbnb-base-15.0.0.tgz#6b09add90ac79c2f8d723a2580e07f3925afd236"
-  integrity sha512-xaX3z4ZZIcFLvh2oUNvcX5oEofXda7giYmuplVxoOg5A7EXJMrUyqRgR+mhDhPK8LZ4PttFOBvCYDbX3sUoUig==
-  dependencies:
-    confusing-browser-globals "^1.0.10"
-    object.assign "^4.1.2"
-    object.entries "^1.1.5"
-    semver "^6.3.0"
-
-eslint-config-nodebb@0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/eslint-config-nodebb/-/eslint-config-nodebb-0.1.1.tgz#da29bca090442d70a8532cc9e8774ef4651ed000"
-  integrity sha512-+LSX8iYe10fKb6k4JuyMygce7GQMSMsttdgi+BO+v+P3tXXxH//OUnEfZ2cbTungZap9Z8NuK6Tog1wrRQo6CQ==
-  dependencies:
-    eslint-config-airbnb-base "15.0.0"
 
 eslint-config-prettier@^8.5.0:
   version "8.5.0"
@@ -11481,7 +11452,7 @@ object-visit@^1.0.0:
   dependencies:
     isobject "^3.0.0"
 
-object.assign@^4.1.2, object.assign@^4.1.3, object.assign@^4.1.4:
+object.assign@^4.1.3, object.assign@^4.1.4:
   version "4.1.4"
   resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.4.tgz#9673c7c7c351ab8c4d0b516f4343ebf4dfb7799f"
   integrity sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==


### PR DESCRIPTION
Copied adf-to-md code from https://github.com/julianlam/adf-to-md/blob/main/index.js and added case to properly convert images to markdown

Demo below shows that the body with an image was properly converted to markdown (and then converted back to ADF to be displayed in the editor)

https://user-images.githubusercontent.com/42781446/217665602-f7629944-1060-460d-a426-4d1c876021c5.mov

