### PR TITLE
Make fontawesome icons not overflow

### DIFF
--- a/frontend/src/components/atoms/Icon.tsx
+++ b/frontend/src/components/atoms/Icon.tsx
@@ -33,15 +33,13 @@ export const Icon = ({ icon, size = 'default', color, colorHex, className, hidde
     const dimension = Dimensions.iconSize[size]
     // priority is color -> colorHex -> black
     const iconColor = color ? Colors.icon[color] : colorHex ?? Colors.icon.black
-    const getIcon = () => {
-        if (hidden) return null
-        if (typeof icon === 'string') return <ImageContainer src={icon} />
-        return <FontAwesomeIcon icon={icon} color={iconColor} />
-    }
 
-    return (
-        <IconContainer size={dimension} className={className}>
-            {getIcon()}
-        </IconContainer>
-    )
+    if (hidden) return null
+    if (typeof icon === 'string')
+        return (
+            <IconContainer size={dimension} className={className}>
+                <ImageContainer src={icon} />
+            </IconContainer>
+        )
+    return <FontAwesomeIcon icon={icon} color={iconColor} className={className} width={dimension} height={dimension} />
 }


### PR DESCRIPTION
I realized we weren't actually scaling down the sizes of the fontawesome icons. We would set the width the container, but the icon itself would overflow:

Ex:
<img width="168" alt="Screenshot 2023-02-08 at 3 52 43 PM" src="https://user-images.githubusercontent.com/9156543/217669914-fdf65541-59bf-4823-a9e9-ce0a7847c2d3.png">
