### PR TITLE
Task duplication improvements

### DIFF
--- a/frontend/src/components/radix/TaskActionsDropdown.tsx
+++ b/frontend/src/components/radix/TaskActionsDropdown.tsx
@@ -51,9 +51,9 @@ const TaskActionsDropdown = ({ task }: TaskActionsDropdownProps) => {
                                       modifyTask(
                                           {
                                               id: optimisticId,
-                                              priorityNormalized: task.priority_normalized,
-                                              dueDate: task.due_date,
-                                              recurringTaskTemplateId: task.recurring_task_template_id,
+                                              priorityNormalized: task.priority_normalized || undefined,
+                                              dueDate: task.due_date || undefined,
+                                              recurringTaskTemplateId: task.recurring_task_template_id || undefined,
                                           },
                                           optimisticId
                                       )

--- a/frontend/src/components/radix/TaskContextMenuWrapper.tsx
+++ b/frontend/src/components/radix/TaskContextMenuWrapper.tsx
@@ -143,9 +143,9 @@ const TaskContextMenuWrapper = ({ task, sectionId, parentTask, children, onOpenC
                           modifyTask(
                               {
                                   id: optimisticId,
-                                  priorityNormalized: task.priority_normalized,
-                                  dueDate: task.due_date,
-                                  recurringTaskTemplateId: task.recurring_task_template_id,
+                                  priorityNormalized: task.priority_normalized || undefined,
+                                  dueDate: task.due_date || undefined,
+                                  recurringTaskTemplateId: task.recurring_task_template_id || undefined,
                               },
                               optimisticId
                           )


### PR DESCRIPTION
bugfix where the modify request would fail because it would send an empty string as a due-date. It no longer does this. Still works for all task types: just creates a GT task with the same body/title/due-date/priority.