### PR TITLE
Reload supported views after creating a new folder

### DIFF
--- a/frontend/src/services/api/task-section.hooks.ts
+++ b/frontend/src/services/api/task-section.hooks.ts
@@ -31,7 +31,7 @@ export const useAddTaskSection = () => {
 
     return useQueuedMutation((data: TAddTaskSectionData) => addTaskSection(data), {
         tag: 'tasks',
-        invalidateTagsOnSettled: ['tasks', 'settings'],
+        invalidateTagsOnSettled: ['tasks', 'settings', 'overview-supported-views'],
         onMutate: async (data) => {
             await queryClient.cancelQueries('tasks')
 


### PR DESCRIPTION
Previously you wouldn't see folder you just created in the edit lists modal