### PR TITLE
Reduce number of sentry errors from Linear webhook

### DIFF
--- a/backend/api/linear_webhook.go
+++ b/backend/api/linear_webhook.go
@@ -130,7 +130,7 @@ func (api *API) LinearWebhook(c *gin.Context) {
 }
 
 func (api *API) processLinearIssueWebhook(c *gin.Context, webhookPayload LinearWebhookPayload, issuePayload LinearIssuePayload) error {
-	token, err := database.GetExternalTokenByExternalID(api.DB, issuePayload.AssigneeID, external.TASK_SERVICE_ID_LINEAR)
+	token, err := database.GetExternalTokenByExternalID(api.DB, issuePayload.AssigneeID, external.TASK_SERVICE_ID_LINEAR, false)
 	if err != nil {
 		// if the owner of the task is not found, we must check if the task exists
 		// if the task does exist, we must delete as we do not want it to show on the user's list
@@ -172,7 +172,7 @@ func (api *API) createOrModifyIssueFromPayload(userID primitive.ObjectID, accoun
 		task.IsCompleted = &isCompleted
 	}
 
-	dbTask, err := database.GetTaskByExternalIDWithoutUser(api.DB, issuePayload.ID)
+	dbTask, err := database.GetTaskByExternalIDWithoutUser(api.DB, issuePayload.ID, false)
 	if err != nil && err != mongo.ErrNoDocuments {
 		logger := logging.GetSentryLogger()
 		logger.Error().Err(err).Msg("could not find matching linear issue")
@@ -199,7 +199,7 @@ func (api *API) createOrModifyIssueFromPayload(userID primitive.ObjectID, accoun
 }
 
 func (api *API) removeIssueFromPayload(userID primitive.ObjectID, issuePayload LinearIssuePayload) error {
-	task, err := database.GetTaskByExternalIDWithoutUser(api.DB, issuePayload.ID)
+	task, err := database.GetTaskByExternalIDWithoutUser(api.DB, issuePayload.ID, false)
 	if err != nil {
 		return err
 	}
@@ -216,7 +216,7 @@ func (api *API) removeIssueFromPayload(userID primitive.ObjectID, issuePayload L
 func (api *API) processLinearCommentWebhook(c *gin.Context, webhookPayload LinearWebhookPayload, commentPayload LinearCommentPayload) error {
 	var err error
 	logger := logging.GetSentryLogger()
-	task, err := database.GetTaskByExternalIDWithoutUser(api.DB, commentPayload.IssueID)
+	task, err := database.GetTaskByExternalIDWithoutUser(api.DB, commentPayload.IssueID, false)
 	if err != nil {
 		return err
 	}
@@ -405,7 +405,7 @@ func getCompletedLinearStatus(teamStatuses []*database.ExternalTaskStatus) *data
 }
 
 func (api *API) removeTaskOwnerIfExists(issuePayload LinearIssuePayload) {
-	task, err := database.GetTaskByExternalIDWithoutUser(api.DB, issuePayload.ID)
+	task, err := database.GetTaskByExternalIDWithoutUser(api.DB, issuePayload.ID, false)
 	if err != nil {
 		// don't log this error because could be a task that shouldn't exist in GT
 		return

--- a/backend/api/linear_webhook_test.go
+++ b/backend/api/linear_webhook_test.go
@@ -145,7 +145,7 @@ func TestProcessComments(t *testing.T) {
 		router.ServeHTTP(recorder, request)
 		assert.Equal(t, http.StatusOK, recorder.Code)
 
-		task, err := database.GetTaskByExternalIDWithoutUser(db, "externalID")
+		task, err := database.GetTaskByExternalIDWithoutUser(db, "externalID", false)
 		assert.NoError(t, err)
 		assert.Equal(t, 1, len(*task.Comments))
 	})
@@ -160,7 +160,7 @@ func TestProcessComments(t *testing.T) {
 		router.ServeHTTP(recorder, request)
 		assert.Equal(t, http.StatusOK, recorder.Code)
 
-		task, err := database.GetTaskByExternalIDWithoutUser(db, "externalID")
+		task, err := database.GetTaskByExternalIDWithoutUser(db, "externalID", false)
 		assert.NoError(t, err)
 		assert.Equal(t, 1, len(*task.Comments))
 	})
@@ -175,7 +175,7 @@ func TestProcessComments(t *testing.T) {
 		router.ServeHTTP(recorder, request)
 		assert.Equal(t, http.StatusOK, recorder.Code)
 
-		task, err := database.GetTaskByExternalIDWithoutUser(db, "externalID")
+		task, err := database.GetTaskByExternalIDWithoutUser(db, "externalID", false)
 		assert.NoError(t, err)
 		assert.Equal(t, 2, len(*task.Comments))
 	})
@@ -190,7 +190,7 @@ func TestProcessComments(t *testing.T) {
 		router.ServeHTTP(recorder, request)
 		assert.Equal(t, http.StatusOK, recorder.Code)
 
-		task, err := database.GetTaskByExternalIDWithoutUser(db, "externalID")
+		task, err := database.GetTaskByExternalIDWithoutUser(db, "externalID", false)
 		assert.NoError(t, err)
 		assert.Equal(t, 2, len(*task.Comments))
 		assert.Equal(t, "modified text", (*task.Comments)[0].Body)
@@ -206,7 +206,7 @@ func TestProcessComments(t *testing.T) {
 		router.ServeHTTP(recorder, request)
 		assert.Equal(t, http.StatusOK, recorder.Code)
 
-		task, err := database.GetTaskByExternalIDWithoutUser(db, "externalID")
+		task, err := database.GetTaskByExternalIDWithoutUser(db, "externalID", false)
 		assert.NoError(t, err)
 		assert.Equal(t, 1, len(*task.Comments))
 	})
@@ -305,7 +305,7 @@ func TestProcessIssue(t *testing.T) {
 		router.ServeHTTP(recorder, request)
 		assert.Equal(t, http.StatusOK, recorder.Code)
 
-		task, err := database.GetTaskByExternalIDWithoutUser(db, "aaad850c-8df6-482f-90b0-82725bd54155")
+		task, err := database.GetTaskByExternalIDWithoutUser(db, "aaad850c-8df6-482f-90b0-82725bd54155", false)
 		assert.NoError(t, err)
 		assert.Equal(t, "Hello there!", *task.Title)
 		assert.Equal(t, "6942069422", task.CompletedStatus.ExternalID)
@@ -322,7 +322,7 @@ func TestProcessIssue(t *testing.T) {
 		router.ServeHTTP(recorder, request)
 		assert.Equal(t, http.StatusBadRequest, recorder.Code)
 
-		_, err := database.GetTaskByExternalIDWithoutUser(db, "aaad850c-8df6-482f-90b0-82725bd54155")
+		_, err := database.GetTaskByExternalIDWithoutUser(db, "aaad850c-8df6-482f-90b0-82725bd54155", false)
 		assert.Equal(t, mongo.ErrNoDocuments, err)
 
 		body, err := io.ReadAll(recorder.Body)
@@ -340,12 +340,12 @@ func TestProcessIssue(t *testing.T) {
 		router.ServeHTTP(recorder, request)
 		assert.Equal(t, http.StatusOK, recorder.Code)
 
-		task, err := database.GetTaskByExternalIDWithoutUser(db, "aaad850c-8df6-482f-90b0-82725bd54155")
+		task, err := database.GetTaskByExternalIDWithoutUser(db, "aaad850c-8df6-482f-90b0-82725bd54155", false)
 		assert.NoError(t, err)
 		assert.Equal(t, "Hello there!", *task.Title)
 		assert.Equal(t, "6942069422", task.CompletedStatus.ExternalID)
 
-		task, err = database.GetTaskByExternalIDWithoutUser(db, "aaad850c-8df6-482f-90b0-82725bd54155")
+		task, err = database.GetTaskByExternalIDWithoutUser(db, "aaad850c-8df6-482f-90b0-82725bd54155", false)
 		assert.NoError(t, err)
 		taskCollection := database.GetTaskCollection(db)
 		newSectionID := primitive.NewObjectID()
@@ -362,7 +362,7 @@ func TestProcessIssue(t *testing.T) {
 		router.ServeHTTP(recorder, request)
 		assert.Equal(t, http.StatusOK, recorder.Code)
 
-		task, err = database.GetTaskByExternalIDWithoutUser(db, "aaad850c-8df6-482f-90b0-82725bd54155")
+		task, err = database.GetTaskByExternalIDWithoutUser(db, "aaad850c-8df6-482f-90b0-82725bd54155", false)
 		assert.NoError(t, err)
 		assert.Equal(t, "Hello there 2.0!", *task.Title)
 		assert.Equal(t, "6942069422", task.CompletedStatus.ExternalID)
@@ -379,7 +379,7 @@ func TestProcessIssue(t *testing.T) {
 		router.ServeHTTP(recorder, request)
 		assert.Equal(t, http.StatusOK, recorder.Code)
 
-		task, err := database.GetTaskByExternalIDWithoutUser(db, "aaad850c-8df6-482f-90b0-82725bd54155")
+		task, err := database.GetTaskByExternalIDWithoutUser(db, "aaad850c-8df6-482f-90b0-82725bd54155", false)
 		assert.NoError(t, err)
 		assert.Equal(t, "Hello there 2.0!", *task.Title)
 		assert.Equal(t, "6942069422", task.CompletedStatus.ExternalID)
@@ -412,7 +412,7 @@ func TestProcessIssue(t *testing.T) {
 		router.ServeHTTP(recorder, request)
 		assert.Equal(t, http.StatusOK, recorder.Code)
 
-		task, err := database.GetTaskByExternalIDWithoutUser(db, "aaad850c-8df6-482f-90b0-82725bd54155")
+		task, err := database.GetTaskByExternalIDWithoutUser(db, "aaad850c-8df6-482f-90b0-82725bd54155", false)
 		assert.NoError(t, err)
 		assert.Equal(t, true, *task.IsDeleted)
 	})

--- a/backend/database/helpers.go
+++ b/backend/database/helpers.go
@@ -197,8 +197,7 @@ func GetSharedNote(db *mongo.Database, itemID primitive.ObjectID) (*Note, error)
 	return &note, nil
 }
 
-func GetTaskByExternalIDWithoutUser(db *mongo.Database, externalID string) (*Task, error) {
-	logger := logging.GetSentryLogger()
+func GetTaskByExternalIDWithoutUser(db *mongo.Database, externalID string, logError bool) (*Task, error) {
 	taskCollection := GetTaskCollection(db)
 	mongoResult := taskCollection.FindOne(
 		context.Background(),
@@ -209,7 +208,10 @@ func GetTaskByExternalIDWithoutUser(db *mongo.Database, externalID string) (*Tas
 	var task Task
 	err := mongoResult.Decode(&task)
 	if err != nil {
-		logger.Error().Err(err).Msgf("failed to get external task: %+v", externalID)
+		if logError {
+			logger := logging.GetSentryLogger()
+			logger.Error().Err(err).Msgf("failed to get external task: %+v", externalID)
+		}
 		return nil, err
 	}
 	return &task, nil
@@ -787,7 +789,7 @@ func GetExternalToken(db *mongo.Database, externalID string, serviceID string) (
 	return &externalAPIToken, nil
 }
 
-func GetExternalTokenByExternalID(db *mongo.Database, externalID string, serviceID string) (*ExternalAPIToken, error) {
+func GetExternalTokenByExternalID(db *mongo.Database, externalID string, serviceID string, logError bool) (*ExternalAPIToken, error) {
 	var externalAPIToken ExternalAPIToken
 	err := GetExternalTokenCollection(db).FindOne(
 		context.Background(),
@@ -798,9 +800,11 @@ func GetExternalTokenByExternalID(db *mongo.Database, externalID string, service
 			},
 		},
 	).Decode(&externalAPIToken)
-	logger := logging.GetSentryLogger()
 	if err != nil {
-		logger.Error().Err(err).Msg("failed to load external api token")
+		if logError {
+			logger := logging.GetSentryLogger()
+			logger.Error().Err(err).Msg("failed to load external api token")
+		}
 		return nil, err
 	}
 	return &externalAPIToken, nil

--- a/backend/database/helpers_test.go
+++ b/backend/database/helpers_test.go
@@ -557,12 +557,12 @@ func TestGetTaskByExternalIDWithoutUser(t *testing.T) {
 	assert.NoError(t, err)
 
 	t.Run("WrongID", func(t *testing.T) {
-		respTask, err := GetTaskByExternalIDWithoutUser(db, "invalid")
+		respTask, err := GetTaskByExternalIDWithoutUser(db, "invalid", false)
 		assert.Equal(t, mongo.ErrNoDocuments, err)
 		assert.Nil(t, respTask)
 	})
 	t.Run("Success", func(t *testing.T) {
-		respTask, err := GetTaskByExternalIDWithoutUser(db, "123abd")
+		respTask, err := GetTaskByExternalIDWithoutUser(db, "123abd", false)
 		assert.NoError(t, err)
 		assert.Equal(t, task1.ID, respTask.ID)
 	})
@@ -1014,15 +1014,15 @@ func TestGetExternalTokeByExternalID(t *testing.T) {
 	assert.NoError(t, err)
 
 	t.Run("WrongExternalID", func(t *testing.T) {
-		_, err := GetExternalTokenByExternalID(db, "wrong account", serviceID)
+		_, err := GetExternalTokenByExternalID(db, "wrong account", serviceID, false)
 		assert.Equal(t, mongo.ErrNoDocuments, err)
 	})
 	t.Run("WrongServiceID", func(t *testing.T) {
-		_, err := GetExternalTokenByExternalID(db, externalID, "wrong service")
+		_, err := GetExternalTokenByExternalID(db, externalID, "wrong service", false)
 		assert.Equal(t, mongo.ErrNoDocuments, err)
 	})
 	t.Run("Success", func(t *testing.T) {
-		token, err := GetExternalTokenByExternalID(db, externalID, serviceID)
+		token, err := GetExternalTokenByExternalID(db, externalID, serviceID, false)
 		assert.NoError(t, err)
 		assert.Equal(t, userID, token.UserID)
 		assert.Equal(t, serviceID, token.ServiceID)


### PR DESCRIPTION
Sentry was logging a lot of errors for these (our top 4 most hit error endpoints are related to these). However, it is expected behavior. So, I added the option to log if we want, but by default are not logging this type of error.