### PR TITLE
Add event edge highlights reduce opacity on event background color

### DIFF
--- a/frontend/src/components/atoms/SelectableContainer.tsx
+++ b/frontend/src/components/atoms/SelectableContainer.tsx
@@ -1,6 +1,5 @@
 import styled from 'styled-components'
 import { Border, Colors, Shadows } from '../../styles'
-import { TItemEdgeColor } from '../../styles/colors'
 
 const SelectableContainer = styled.div<{ isSelected: boolean }>`
     background-color: ${Colors.background.white};
@@ -14,12 +13,12 @@ const SelectableContainer = styled.div<{ isSelected: boolean }>`
     }
 `
 
-export const EdgeHighlight = styled.div<{ color: TItemEdgeColor; squareStart?: boolean; squareEnd?: boolean }>`
+export const EdgeHighlight = styled.div<{ color: string; squareStart?: boolean; squareEnd?: boolean }>`
     position: absolute;
     left: 0;
     height: 100%;
     width: 4px;
-    background-color: ${(props) => Colors.itemEdge[props.color]};
+    background-color: ${(props) => props.color};
     border-top-left-radius: ${(props) => (props.squareStart ? '0' : Border.radius.mini)};
     border-bottom-left-radius: ${(props) => (props.squareEnd ? '0' : Border.radius.mini)};
 `

--- a/frontend/src/components/calendar/CalendarEvents-styles.tsx
+++ b/frontend/src/components/calendar/CalendarEvents-styles.tsx
@@ -171,7 +171,7 @@ export const EventFill = styled.div<{
     box-sizing: border-box;
     box-shadow: ${Shadows.light};
     /* add opacity to background color */
-    background-color: ${(props) => `${props.backgroundColorHex}80`};
+    background-color: ${(props) => `${props.backgroundColorHex}1A`};
     border-top-left-radius: ${(props) => (props.squareStart ? '0' : Border.radius.mini)};
     border-top-right-radius: ${(props) => (props.squareStart ? '0' : Border.radius.mini)};
     border-bottom-left-radius: ${(props) => (props.squareEnd ? '0' : Border.radius.mini)};

--- a/frontend/src/components/calendar/EventBody.tsx
+++ b/frontend/src/components/calendar/EventBody.tsx
@@ -121,7 +121,11 @@ function EventBody(props: EventBodyProps): JSX.Element {
                         backgroundColorHex={getCalendarColor(props.event.color_id || calendar?.color_id || '')}
                     />
                     {isPreviewMode && (
-                        <EdgeHighlight color="blue" squareStart={startedBeforeToday} squareEnd={endedAfterToday} />
+                        <EdgeHighlight
+                            color={getCalendarColor(props.event.color_id || calendar?.color_id || '')}
+                            squareStart={startedBeforeToday}
+                            squareEnd={endedAfterToday}
+                        />
                     )}
                     <ResizeHandle event={props.event} />
                 </EventBodyStyle>

--- a/frontend/src/components/molecules/ItemContainer.tsx
+++ b/frontend/src/components/molecules/ItemContainer.tsx
@@ -1,7 +1,6 @@
 import { forwardRef } from 'react'
 import styled from 'styled-components'
 import { Border, Colors, Shadows, Spacing } from '../../styles'
-import { TItemEdgeColor } from '../../styles/colors'
 import { EdgeHighlight } from '../atoms/SelectableContainer'
 
 const ItemContainerDiv = styled.div<{ isSelected?: boolean; isCompact?: boolean; forceHoverStyle?: boolean }>`
@@ -37,10 +36,9 @@ interface ItemContainerProps {
     children: React.ReactNode
     forceHoverStyle?: boolean
     className?: string
-    edgeColor?: TItemEdgeColor
 }
 const ItemContainer = forwardRef<HTMLDivElement, ItemContainerProps>(
-    ({ isSelected, isCompact = false, onClick, children, forceHoverStyle, className, edgeColor = 'orange' }, ref) => (
+    ({ isSelected, isCompact = false, onClick, children, forceHoverStyle, className }, ref) => (
         <ItemContainerDiv
             isSelected={isSelected}
             isCompact={isCompact}
@@ -49,7 +47,7 @@ const ItemContainer = forwardRef<HTMLDivElement, ItemContainerProps>(
             forceHoverStyle={forceHoverStyle}
             className={className}
         >
-            {isSelected && <EdgeHighlight color={edgeColor} />}
+            {isSelected && <EdgeHighlight color={Colors.gtColor.orange} />}
             {children}
         </ItemContainerDiv>
     )

--- a/frontend/src/components/pull-requests/PullRequest.tsx
+++ b/frontend/src/components/pull-requests/PullRequest.tsx
@@ -1,6 +1,7 @@
 import { useCallback } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import Log from '../../services/api/log'
+import { Colors } from '../../styles'
 import { PULL_REQUEST_ACTIONS } from '../../utils/sortAndFilter/pull-requests.config'
 import { TPullRequest } from '../../utils/types'
 import CommentCount from '../atoms/CommentCount'
@@ -35,7 +36,7 @@ const PullRequest = ({ pullRequest, link, isSelected }: PullRequestProps) => {
 
     return (
         <PullRequestRow onClick={onClickHandler} isSelected={isSelected}>
-            {isSelected && <EdgeHighlight color="orange" />}
+            {isSelected && <EdgeHighlight color={Colors.gtColor.orange} />}
             <TitleContainer>{title}</TitleContainer>
             <Column>
                 <Status description={statusDescription} status={status.text} color={status.color} />

--- a/frontend/src/styles/colors.ts
+++ b/frontend/src/styles/colors.ts
@@ -100,10 +100,3 @@ export const gtColor = {
     orange: ORANGE._1,
     blue: BLUE._3,
 }
-
-export const itemEdge = {
-    orange: ORANGE._1,
-    blue: BLUE._3,
-}
-
-export type TItemEdgeColor = keyof typeof itemEdge


### PR DESCRIPTION
The edge highlight is still feature locked. The opacity change on the events is not feature-locked as it's part of the new designs and improves contrast. Some events are currently difficult to read on master.

<img width="297" alt="Screenshot 2023-02-09 at 3 08 40 PM" src="https://user-images.githubusercontent.com/31417618/217950478-28869052-659f-4410-8b4e-78f2c0709af9.png">
