### PR TITLE
Fix hidden icons

### DIFF
--- a/frontend/src/components/atoms/Icon.tsx
+++ b/frontend/src/components/atoms/Icon.tsx
@@ -22,6 +22,11 @@ const ImageContainer = styled.img`
     width: 100%;
     aspect-ratio: 1;
 `
+const StyledFontAwesomeIcon = styled(FontAwesomeIcon)<{ height: string; hidden?: boolean }>`
+    height: ${({ height }) => height};
+    visibility: ${({ hidden }) => (hidden ? 'hidden' : 'visible')};
+    aspect-ratio: 1;
+`
 interface IconProps {
     icon: TIconType
     size?: TIconSize
@@ -35,20 +40,20 @@ export const Icon = ({ icon, size = 'default', color, colorHex, className, hidde
     // priority is color -> colorHex -> black
     const iconColor = color ? Colors.icon[color] : colorHex ?? Colors.icon.black
 
-    if (hidden) return null
     if (typeof icon === 'string')
         return (
             <IconContainer size={dimension} className={className}>
-                <ImageContainer src={icon} />
+                {!hidden && <ImageContainer src={icon} />}
             </IconContainer>
         )
     return (
         <Flex>
-            <FontAwesomeIcon
+            <StyledFontAwesomeIcon
                 icon={icon}
                 color={iconColor}
                 className={className}
-                style={{ height: dimension, aspectRatio: 1 }}
+                height={dimension}
+                hidden={hidden}
             />
         </Flex>
     )


### PR DESCRIPTION
Fixed bug where the `hidden` `Icon`s weren't taking up any space 
 
Before:

<img width="313" alt="image" src="https://user-images.githubusercontent.com/42781446/218341537-32ee4352-264c-491e-9d9a-2ee27716b628.png">

After:
<img width="314" alt="image" src="https://user-images.githubusercontent.com/42781446/218341550-54c05172-6097-405b-87f5-edd22602aa41.png">
