### PR TITLE
[jira] make clicking the area below a paragraph select the paragraph above 

### DIFF
--- a/frontend/src/components/atoms/GTTextField/AtlassianEditor/Editor.tsx
+++ b/frontend/src/components/atoms/GTTextField/AtlassianEditor/Editor.tsx
@@ -42,11 +42,13 @@ const EditorContainer = styled.div<{ isMarkdown: boolean }>`
         height: 100%;
         padding: ${Spacing._8};
         box-sizing: border-box;
-        > * {
-            margin-bottom: ${Spacing._8};
+        > :not(.code-block) {
+            padding-bottom: ${Spacing._8};
+            margin: 0;
         }
         > .code-block {
-            margin: 0;
+            margin: 0 0 ${Spacing._8};
+            background-color: red;
         }
     }
     .assistive {


### PR DESCRIPTION
except for code blocks because adding padding causes the weird highlight bug 

https://user-images.githubusercontent.com/42781446/218562211-f483e072-459b-4c86-8310-9fff17e54cc6.mov

