### PR TITLE
Use Atlassian editor for markdown (again)

### DIFF
--- a/frontend/src/components/atoms/GTTextField/GTTextField.tsx
+++ b/frontend/src/components/atoms/GTTextField/GTTextField.tsx
@@ -1,5 +1,6 @@
 import { Suspense, forwardRef, lazy, useRef } from 'react'
 import styled from 'styled-components'
+import { usePreviewMode } from '../../../hooks'
 import { Border, Colors, Shadows } from '../../../styles'
 import { stopKeydownPropogation } from '../../../utils/utils'
 import Spinner from '../Spinner'
@@ -54,12 +55,16 @@ const Container = styled.div<{
 `
 
 const GTTextField = forwardRef((props: GTTextFieldProps, ref) => {
+    const { isPreviewMode } = usePreviewMode()
     const containerRef = useRef<HTMLDivElement>(null)
 
     const getEditor = () => {
         if (props.type === 'plaintext') {
             return <PlainTextEditor ref={ref} {...props} />
         } else if (props.type === 'markdown') {
+            if (isPreviewMode) {
+                return <AtlassianEditor {...props} />
+            }
             return <MarkdownEditor {...props} />
         } else if (props.type === 'atlassian') {
             return <AtlassianEditor {...props} />


### PR DESCRIPTION
This makes all tasks use the jira editor in preview mode

This will cause the app to break when switching between modes, so hopefully we can get this tested & approved by the team so we can fully migrate over to using the jira editor everywhere