### PR TITLE
Allow new datetime format for modify requests

### DIFF
--- a/backend/api/task_modify.go
+++ b/backend/api/task_modify.go
@@ -30,15 +30,15 @@ type TaskChangeable struct {
 }
 
 type TaskItemChangeableFields struct {
-	Task           TaskChangeable      `json:"task,omitempty" bson:"task,omitempty"`
-	Title          *string             `json:"title,omitempty" bson:"title,omitempty"`
-	Body           *string             `json:"body,omitempty" bson:"body,omitempty"`
-	DueDate        *primitive.DateTime `json:"due_date,omitempty" bson:"due_date,omitempty"`
-	TimeAllocation *int64              `json:"time_duration,omitempty" bson:"time_allocated,omitempty"`
-	IsCompleted    *bool               `json:"is_completed,omitempty" bson:"is_completed,omitempty"`
-	CompletedAt    primitive.DateTime  `json:"completed_at,omitempty" bson:"completed_at"`
-	IsDeleted      *bool               `json:"is_deleted,omitempty" bson:"is_deleted,omitempty"`
-	DeletedAt      primitive.DateTime  `json:"deleted_at,omitempty" bson:"deleted_at"`
+	Task           TaskChangeable     `json:"task,omitempty" bson:"task,omitempty"`
+	Title          *string            `json:"title,omitempty" bson:"title,omitempty"`
+	Body           *string            `json:"body,omitempty" bson:"body,omitempty"`
+	DueDate        *string            `json:"due_date,omitempty" bson:"due_date,omitempty"`
+	TimeAllocation *int64             `json:"time_duration,omitempty" bson:"time_allocated,omitempty"`
+	IsCompleted    *bool              `json:"is_completed,omitempty" bson:"is_completed,omitempty"`
+	CompletedAt    primitive.DateTime `json:"completed_at,omitempty" bson:"completed_at"`
+	IsDeleted      *bool              `json:"is_deleted,omitempty" bson:"is_deleted,omitempty"`
+	DeletedAt      primitive.DateTime `json:"deleted_at,omitempty" bson:"deleted_at"`
 }
 
 type TaskModifyParams struct {
@@ -98,11 +98,27 @@ func (api *API) TaskModify(c *gin.Context) {
 		return
 	}
 
+	var dueDate primitive.DateTime
+	if modifyParams.TaskItemChangeableFields.DueDate != nil {
+		yearMonthDayDate, yearMonthDayErr := time.Parse(constants.YEAR_MONTH_DAY_FORMAT, *modifyParams.TaskItemChangeableFields.DueDate)
+		rfcDate, rfcErr := time.Parse(time.RFC3339, *modifyParams.TaskItemChangeableFields.DueDate)
+
+		if yearMonthDayErr != nil && rfcErr != nil {
+			c.JSON(400, gin.H{"detail": "due_date is not a valid date"})
+			return
+		}
+		if yearMonthDayErr == nil {
+			dueDate = primitive.NewDateTimeFromTime(yearMonthDayDate)
+		} else {
+			dueDate = primitive.NewDateTimeFromTime(rfcDate)
+		}
+	}
+
 	if modifyParams.TaskItemChangeableFields != (TaskItemChangeableFields{}) {
 		updateTask := database.Task{
 			Title:              modifyParams.TaskItemChangeableFields.Title,
 			Body:               modifyParams.TaskItemChangeableFields.Body,
-			DueDate:            modifyParams.TaskItemChangeableFields.DueDate,
+			DueDate:            &dueDate,
 			TimeAllocation:     modifyParams.TaskItemChangeableFields.TimeAllocation,
 			IsCompleted:        modifyParams.TaskItemChangeableFields.IsCompleted,
 			CompletedAt:        modifyParams.TaskItemChangeableFields.CompletedAt,

--- a/backend/api/task_modify_test.go
+++ b/backend/api/task_modify_test.go
@@ -998,6 +998,43 @@ func TestEditFields(t *testing.T) {
 		expectedTask.DueDate = &expectedDueDate
 		utils.AssertTasksEqual(t, &expectedTask, &task)
 	})
+	t.Run("Edit Due Date with \"2006-01-02\" Date Format", func(t *testing.T) {
+		expectedTask := sampleTask
+		expectedTask.UserID = userID
+		insertResult, err := taskCollection.InsertOne(
+			context.Background(),
+			expectedTask,
+		)
+		assert.NoError(t, err)
+		insertedTaskID := insertResult.InsertedID.(primitive.ObjectID)
+
+		dueDate, err := time.Parse("2006-01-02", "2021-12-06")
+		assert.NoError(t, err)
+		api, dbCleanup := GetAPIWithDBCleanup()
+		defer dbCleanup()
+		router := GetRouter(api)
+		request, _ := http.NewRequest(
+			"PATCH",
+			"/tasks/modify/"+insertedTaskID.Hex()+"/",
+			bytes.NewBuffer([]byte(`{"due_date": "`+dueDate.Format("2006-01-02")+`"}`)))
+		request.Header.Add("Authorization", "Bearer "+authToken)
+		recorder := httptest.NewRecorder()
+		router.ServeHTTP(recorder, request)
+		assert.Equal(t, http.StatusOK, recorder.Code)
+		body, err := io.ReadAll(recorder.Body)
+		assert.NoError(t, err)
+		assert.Equal(t, "{}", string(body))
+
+		var task database.Task
+
+		err = taskCollection.FindOne(context.Background(), bson.M{"_id": insertedTaskID}).Decode(&task)
+		assert.NoError(t, err)
+
+		expectedDueDate := primitive.NewDateTimeFromTime(dueDate)
+		expectedTask.DueDate = &expectedDueDate
+		utils.AssertTasksEqual(t, &expectedTask, &task)
+
+	})
 	t.Run("Edit Due Date Empty", func(t *testing.T) {
 		expectedTask := sampleTask
 		expectedTask.UserID = userID
@@ -1022,7 +1059,7 @@ func TestEditFields(t *testing.T) {
 
 		body, err := io.ReadAll(recorder.Body)
 		assert.NoError(t, err)
-		assert.Equal(t, "{\"detail\":\"parameter missing or malformatted\"}", string(body))
+		assert.Equal(t, "{\"detail\":\"due_date is not a valid date\"}", string(body))
 	})
 	t.Run("Edit Time Duration Success", func(t *testing.T) {
 		expectedTask := sampleTask


### PR DESCRIPTION
Allow task modify requests with string `due_date` field formatted as “2006-01-02”. This should still allow requests of the previous format (`time.RFC3339`)
