### PR TITLE
Stop rich text popup from appearing above modals

### DIFF
--- a/frontend/src/components/atoms/GTTextField/AtlassianEditor/Editor.tsx
+++ b/frontend/src/components/atoms/GTTextField/AtlassianEditor/Editor.tsx
@@ -51,6 +51,9 @@ const EditorContainer = styled.div<{ isMarkdown: boolean }>`
             background-color: red;
         }
     }
+    [aria-label*='floating controls'] {
+        z-index: 1 !important;
+    }
     .assistive {
         display: none;
     }


### PR DESCRIPTION
fixes this:
![image](https://user-images.githubusercontent.com/42781446/218651160-911c8d76-2c74-41a7-a308-98a34fe714d4.png)

fun css feature to match `Hyperlink floating controls` and `Codeblock floating controls`