### PR TITLE
Format whitespace in event bodies

### DIFF
--- a/frontend/src/components/molecules/EventDetailPopover-styles.tsx
+++ b/frontend/src/components/molecules/EventDetailPopover-styles.tsx
@@ -45,6 +45,7 @@ export const Description = styled.div`
     overflow-y: auto;
     max-height: ${MAX_POPUP_HEIGHT}px;
     margin-bottom: ${Spacing._16};
+    white-space: pre-wrap;
 `
 export const FlexAnchor = styled(NoStyleAnchor)`
     flex: 1;


### PR DESCRIPTION
Before:
<img width="289" alt="Screenshot 2023-02-14 at 12 21 17 PM" src="https://user-images.githubusercontent.com/9156543/218811326-e3124d02-abe7-4894-b992-82d6f958d88d.png">
After:
<img width="293" alt="Screenshot 2023-02-14 at 12 21 10 PM" src="https://user-images.githubusercontent.com/9156543/218811325-731512f5-65f9-4758-9917-c23792f27557.png">