### PR TITLE
Unlock filtering for recurring task templates

### DIFF
--- a/frontend/src/components/views/RecurringTasksView.tsx
+++ b/frontend/src/components/views/RecurringTasksView.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
-import { useItemSelectionController, usePreviewMode } from '../../hooks'
+import { useItemSelectionController } from '../../hooks'
 import Log from '../../services/api/log'
 import { useBackfillRecurringTasks, useRecurringTaskTemplates } from '../../services/api/recurring-tasks.hooks'
 import { icons } from '../../styles/images'
@@ -27,7 +27,6 @@ const RecurringTasksView = () => {
     const { recurringTaskId } = useParams()
     const navigate = useNavigate()
     const { calendarType } = useCalendarContext()
-    const { isPreviewMode } = usePreviewMode()
 
     const sortAndFilterSettings = useSortAndFilterSettings<TRecurringTaskTemplate>(
         RECURRING_TASK_SORT_AND_FILTER_CONFIG
@@ -68,7 +67,7 @@ const RecurringTasksView = () => {
                         <Spinner />
                     ) : (
                         <>
-                            {isPreviewMode && <SortAndFilterSelectors settings={sortAndFilterSettings} />}
+                            <SortAndFilterSelectors settings={sortAndFilterSettings} />
                             <AddRecurringTask />
                             {filteredRecurringTasks.map((recurringTask) => (
                                 <RecurringTask


### PR DESCRIPTION
Deleted recurring task templates are already being sent to the frontend, but they are filtered out by default. Unlocking this enables users to recover deleted recurring task templates by choosing to un-filter them.

<img width="573" alt="Screenshot 2023-02-16 at 10 54 31 AM" src="https://user-images.githubusercontent.com/31417618/219418651-b8cb4ccb-47d0-48a1-a735-b46d7e110924.png">
