### PR TITLE
Suppress more jira error messages

### DIFF
--- a/frontend/src/jank-mode.ts
+++ b/frontend/src/jank-mode.ts
@@ -20,7 +20,6 @@ const suppressConsoleErrors = () => {
         if (message && messagesToSuppress.some((msg) => message.includes(msg))) {
             return
         } else {
-            console.log('uhh', message)
             backupConsoleError(message, ...optionalParams)
         }
     }


### PR DESCRIPTION
sometimes links would have a `%s` at the end for some reason, so this should be a cleaner and faster solution