### PR TITLE
Add calendar_id to event object in /events/create/

### DIFF
--- a/backend/api/event_create.go
+++ b/backend/api/event_create.go
@@ -76,6 +76,7 @@ func (api *API) EventCreate(c *gin.Context) {
 		IDExternal:          externalEventID.Hex(),
 		SourceID:            sourceID,
 		SourceAccountID:     eventCreateObject.AccountID,
+		CalendarID:          eventCreateObject.CalendarID,
 		Title:               eventCreateObject.Summary,
 		Body:                eventCreateObject.Description,
 		DatetimeEnd:         primitive.NewDateTimeFromTime(*eventCreateObject.DatetimeEnd),

--- a/backend/api/event_create_test.go
+++ b/backend/api/event_create_test.go
@@ -59,7 +59,7 @@ func TestEventCreate(t *testing.T) {
 		dbEvent, err := database.GetCalendarEvent(api.DB, eventID, userID)
 		assert.NoError(t, err)
 		assert.Equal(t, eventID, dbEvent.ID)
-		checkEventMatchesCreateObject(t, *dbEvent, defaultEventCreateObject)
+		checkEventMatchesCreateObject(t, *dbEvent, eventCreateObj)
 	})
 	t.Run("SuccessLinkedView", func(t *testing.T) {
 		viewCollection := database.GetViewCollection(db)


### PR DESCRIPTION
#3061 introduced filters for account ID and calendar ID, but this returned no matches because the calendar ID was not being set. This PR sets the calendar ID in the /events/create/ endpoint.

This caused a new event to be created, instead of modifying the existing one in our DB. Which caused the linked source info to be deleted, causing linked task/PR/view logos to be deleted once the event_list endpoint was called. It also caused the wrong event ID to be returned in the /event/create/ endpoint, which stopped optimistic updates from working before the event_list endpoint returned the new real ID.

demo: 

https://user-images.githubusercontent.com/42781446/220748120-1900ec3e-1b51-4cac-b1f1-b016a5b52cbd.mov

