### PR TITLE
Fix bug that showed 'Back to parent' message for non-subtasks

### DIFF
--- a/frontend/src/components/details/TaskDetails.tsx
+++ b/frontend/src/components/details/TaskDetails.tsx
@@ -132,7 +132,7 @@ const TaskDetails = ({ task, isRecurringTaskTemplate }: TaskDetailsProps) => {
     const dateTimeEnd = DateTime.fromISO(meeting_preparation_params?.datetime_end || '')
 
     const isMeetingPreparationTask = !!meeting_preparation_params
-    const isSubtask = task.id_parent != null
+    const isSubtask = !!task.id_parent
 
     const titleRef = useRef<HTMLTextAreaElement>(null)
 


### PR DESCRIPTION
`"" == null` resolves to false