### PR TITLE
Select task-to-cal calendar when first calendar account is added

### DIFF
--- a/frontend/src/services/api/events.hooks.ts
+++ b/frontend/src/services/api/events.hooks.ts
@@ -336,8 +336,12 @@ export const useSelectedCalendars = () => {
         [],
         true
     )
-    const { field_value: taskToCalAccount } = useSetting('calendar_account_id_for_new_tasks')
-    const { field_value: taskToCalCalendar } = useSetting('calendar_calendar_id_for_new_tasks')
+    const { field_value: taskToCalAccount, updateSetting: setTaskToCalAccount } = useSetting(
+        'calendar_account_id_for_new_tasks'
+    )
+    const { field_value: taskToCalCalendar, updateSetting: setTaskToCalCalendar } = useSetting(
+        'calendar_calendar_id_for_new_tasks'
+    )
 
     // update selected calendars when calendar accounts are added/removed
     useEffect(() => {
@@ -420,8 +424,8 @@ export const useSelectedCalendars = () => {
         [selectedCalendars]
     )
 
-    // ensure that task-to-cal calendar is always selected
     useEffect(() => {
+        // ensure that task-to-cal calendar is always selected
         if (!isCalendarSelected(taskToCalAccount, taskToCalCalendar)) {
             const calendar = calendars
                 ?.find((account) => account.account_id === taskToCalAccount)
@@ -429,6 +433,12 @@ export const useSelectedCalendars = () => {
             if (calendar) {
                 toggleCalendarSelection(taskToCalAccount, calendar)
             }
+        }
+
+        // if the first account is added, select the first calendar
+        if (taskToCalAccount === '' && calendars && calendars.length !== 0) {
+            setTaskToCalAccount(calendars[0].account_id)
+            setTaskToCalCalendar(calendars[0].account_id)
         }
     }, [calendars, isCalendarSelected, taskToCalAccount, taskToCalCalendar, toggleCalendarSelection])
 


### PR DESCRIPTION
Demo showing that when the first account is added, it selects the primary calendar of that account

https://user-images.githubusercontent.com/42781446/221179101-bc9a08d4-489d-4b4a-8619-9300f57c3f75.mov

