### PR TITLE
Correctly navigate after completing last task in task folder

### DIFF
--- a/frontend/src/components/views/TaskSectionView.tsx
+++ b/frontend/src/components/views/TaskSectionView.tsx
@@ -2,7 +2,6 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import styled from 'styled-components'
 import { v4 as uuidv4 } from 'uuid'
-import { DONE_FOLDER_ID, TRASH_FOLDER_ID } from '../../constants'
 import { useKeyboardShortcut } from '../../hooks'
 import { useNavigateToTask } from '../../hooks'
 import useItemSelectionController from '../../hooks/useItemSelectionController'
@@ -75,12 +74,7 @@ const TaskSectionView = () => {
     const folder = useMemo(() => folders?.find(({ id }) => id === params.section), [folders, params.section])
     const folderTasks = useMemo(() => {
         if (!folder) return []
-        if (folder.id === DONE_FOLDER_ID) {
-            return allTasks?.filter((t) => t.is_done) || []
-        } else if (folder.id === TRASH_FOLDER_ID) {
-            return allTasks?.filter((t) => t.is_deleted) || []
-        }
-        return allTasks?.filter((t) => t.id_folder === folder.id && !t.is_deleted && !t.is_deleted) || []
+        return allTasks?.filter((t) => t.id_folder === folder.id) || []
     }, [allTasks, folder])
 
     const sortAndFilterSettings = useSortAndFilterSettings<TTaskV4>(TASK_SORT_AND_FILTER_CONFIG, folder?.id, '_main')


### PR DESCRIPTION
Previously we weren't navigating to the unselected task state after completing the last task in a folder

Before:

https://user-images.githubusercontent.com/9156543/222251116-7d9bbfd5-6667-4116-a9d9-3f331846ce75.mov

After:


https://user-images.githubusercontent.com/9156543/222251177-e7c2ef2d-cca5-4f41-8be6-7f9daa6fea64.mov


