### PR TITLE
Use view_items instead of view_item_ids for View More logic

### DIFF
--- a/frontend/src/components/overview/AccordionItem.tsx
+++ b/frontend/src/components/overview/AccordionItem.tsx
@@ -60,7 +60,8 @@ const AccordionItem = ({ list }: AccordionItemProps) => {
     }, [list.view_item_ids.length])
 
     const [visibleItemsCount, setVisibleItemsCount] = useGetVisibleItemCount(list, list.id)
-    const nextPageLength = Math.min(list.view_item_ids.length - visibleItemsCount, PAGE_SIZE)
+
+    const nextPageLength = Math.min(list.view_items.length - visibleItemsCount, PAGE_SIZE)
 
     return (
         <AccordionContainer>
@@ -72,7 +73,7 @@ const AccordionItem = ({ list }: AccordionItemProps) => {
                     {list.is_linked ? (
                         <>
                             <ViewItems view={list} visibleItemsCount={visibleItemsCount} hideHeader />
-                            {visibleItemsCount < list.view_item_ids.length && (
+                            {visibleItemsCount < list.view_items.length && (
                                 <PaginateTextButton
                                     onClick={() => setVisibleItemsCount(visibleItemsCount + nextPageLength)}
                                 >

--- a/frontend/src/hooks/useGetVisibleItemCount.ts
+++ b/frontend/src/hooks/useGetVisibleItemCount.ts
@@ -12,10 +12,10 @@ const useGetVisibleItemCount = (list: TOverviewView, listID: string) => {
     useLayoutEffect(() => {
         setVisibleItemsCount(
             Math.max(
-                // Ensure that visibleItemsCount <= view.view_item_ids.length, and that we do not decrease the number of visible items when selecting a new item
-                Math.min(visibleItemsCount, list.view_item_ids.length),
-                // If view.view_item_ids.length drops below PAGE_SIZE, set visibleItemsCount to view.view_item_ids.length
-                Math.min(list.view_item_ids.length, INITIAL_PAGE_SIZE),
+                // Ensure that visibleItemsCount <= view.view_items.length, and that we do not decrease the number of visible items when selecting a new item
+                Math.min(visibleItemsCount, list.view_items.length),
+                // If view.view_items.length drops below PAGE_SIZE, set visibleItemsCount to view.view_items.length
+                Math.min(list.view_items.length, INITIAL_PAGE_SIZE),
                 // if the selected item is in this view, ensure it is visible
                 list.id === overviewViewId ? list.view_item_ids.findIndex((id) => id === overviewItemId) + 1 : 0
             )


### PR DESCRIPTION
We need to use view_items because it contains the filtered items, whereas view_item_ids contains all items in the list.

Before:
<img width="453" alt="Screenshot 2023-03-03 at 9 30 28 AM" src="https://user-images.githubusercontent.com/9156543/222746503-5e949ee1-2c6c-4848-9bcb-a5f247761bec.png">

After:
<img width="450" alt="Screenshot 2023-03-03 at 9 30 15 AM" src="https://user-images.githubusercontent.com/9156543/222746523-416c0f27-6ad1-4b30-8238-7de4299a3654.png">
