### PR TITLE
Fix ordering of meeting prep tasks

### DIFF
--- a/backend/api/meeting_preparation_task.go
+++ b/backend/api/meeting_preparation_task.go
@@ -62,6 +62,13 @@ func (api *API) GetMeetingPreparationTasksResult(userID primitive.ObjectID, time
 	sort.Slice(*meetingTasks, func(i, j int) bool {
 		return (*meetingTasks)[i].MeetingPreparationParams.DatetimeStart > (*meetingTasks)[j].MeetingPreparationParams.DatetimeStart
 	})
+	if len(*meetingTasks) > 100 {
+		*meetingTasks = (*meetingTasks)[:100]
+	}
+	//Reverse the order of the tasks
+	sort.Slice(*meetingTasks, func(i, j int) bool {
+		return (*meetingTasks)[i].MeetingPreparationParams.DatetimeStart < (*meetingTasks)[j].MeetingPreparationParams.DatetimeStart
+	})
 
 	meetingTaskResult := api.taskListToTaskResultListV4(meetingTasks, userID)
 	// Limit to 100 tasks in response

--- a/backend/api/meeting_preparation_task_test.go
+++ b/backend/api/meeting_preparation_task_test.go
@@ -187,8 +187,8 @@ func TestGetMeetingPreparationTasksResult(t *testing.T) {
 		result, err := api.GetMeetingPreparationTasksResult(userID, 0)
 		assert.NoError(t, err)
 		assert.Len(t, result, 2)
-		assert.Equal(t, "Event1", result[0].Title)
-		assert.Equal(t, "Event2", result[1].Title)
+		assert.Equal(t, "Event2", result[0].Title)
+		assert.Equal(t, "Event1", result[1].Title)
 	})
 	t.Run("TaskWithMissingEvent", func(t *testing.T) {
 		_, err = createTestMeetingPreparationTask(taskCollection, userID, "Event3", "missing", false, timeTwoHoursLater, timeOneDayLater, primitive.NilObjectID)
@@ -197,10 +197,10 @@ func TestGetMeetingPreparationTasksResult(t *testing.T) {
 		result, err := api.GetMeetingPreparationTasksResult(userID, 0)
 		assert.NoError(t, err)
 		assert.Len(t, result, 3)
-		assert.Equal(t, "Event1", result[0].Title)
-		assert.Equal(t, "Event3", result[1].Title)
+		assert.Equal(t, "Event2", result[0].Title)
+		assert.Equal(t, "Event1", result[1].Title)
 		assert.True(t, result[1].MeetingPreparationParams.EventMovedOrDeleted)
-		assert.Equal(t, "Event2", result[2].Title)
+		assert.Equal(t, "Event3", result[2].Title)
 	})
 	t.Run("EventIsNotOnOwnedCalendar", func(t *testing.T) {
 		_, err = createTestEvent(calendarEventCollection, userID, "Event4", primitive.NewObjectID().Hex(), timeOneHourLater, timeOneDayLater, primitive.NilObjectID, "acctid", "other_calid")
@@ -208,9 +208,9 @@ func TestGetMeetingPreparationTasksResult(t *testing.T) {
 		result, err := api.GetMeetingPreparationTasksResult(userID, 0)
 		assert.NoError(t, err)
 		assert.Len(t, result, 3)
-		assert.Equal(t, "Event1", result[0].Title)
-		assert.Equal(t, "Event3", result[1].Title)
-		assert.Equal(t, "Event2", result[2].Title)
+		assert.Equal(t, "Event2", result[0].Title)
+		assert.Equal(t, "Event1", result[1].Title)
+		assert.Equal(t, "Event3", result[2].Title)
 	})
 	t.Run("MeetingHasEnded", func(t *testing.T) {
 		idExternal := primitive.NewObjectID().Hex()
@@ -231,12 +231,12 @@ func TestGetMeetingPreparationTasksResult(t *testing.T) {
 		assert.NotEqual(t, primitive.DateTime(0), item.CompletedAt)
 		assert.Equal(t, true, item.MeetingPreparationParams.HasBeenAutomaticallyCompleted)
 
-		assert.Equal(t, "Event1", res[0].Title)
-		assert.Equal(t, "Event3", res[1].Title)
-		assert.Equal(t, "Event2", res[2].Title)
-		assert.True(t, res[3].IsDone)
 		assert.Len(t, res, 4)
-		assert.Equal(t, "reticulate splines", res[3].Title)
+		assert.Equal(t, "reticulate splines", res[0].Title)
+		assert.True(t, res[0].IsDone)
+		assert.Equal(t, "Event2", res[1].Title)
+		assert.Equal(t, "Event1", res[2].Title)
+		assert.Equal(t, "Event3", res[3].Title)
 	})
 	t.Run("EventMovedToNextDay", func(t *testing.T) {
 		idExternal := primitive.NewObjectID().Hex()
@@ -260,12 +260,12 @@ func TestGetMeetingPreparationTasksResult(t *testing.T) {
 
 		assert.Len(t, res, 5)
 
-		assert.Equal(t, "Event6", res[0].Title)
-		assert.Equal(t, "Event1", res[1].Title)
-		assert.Equal(t, "Event3", res[2].Title)
-		assert.Equal(t, "Event2", res[3].Title)
-		assert.Equal(t, "reticulate splines", res[4].Title)
-		assert.True(t, res[4].IsDone)
+		assert.Equal(t, "reticulate splines", res[0].Title)
+		assert.True(t, res[0].IsDone)
+		assert.Equal(t, "Event2", res[1].Title)
+		assert.Equal(t, "Event1", res[2].Title)
+		assert.Equal(t, "Event3", res[3].Title)
+		assert.Equal(t, "Event6", res[4].Title)
 	})
 	t.Run("LimitResponseTo100Tasks", func(t *testing.T) {
 		authtoken := login("test_limit_100_tasks@generaltask.com", "")
@@ -280,16 +280,20 @@ func TestGetMeetingPreparationTasksResult(t *testing.T) {
 			_, err = createTestMeetingPreparationTask(taskCollection, userID, eventTitle, primitive.NewObjectID().Hex(), false, timeOneHourEarlier, timeOneDayLater, primitive.NilObjectID)
 			assert.NoError(t, err)
 		}
-		// Add a task that should be returned first in the response
-		_, err = createTestMeetingPreparationTask(taskCollection, userID, "Should be first", primitive.NewObjectID().Hex(), false, timeOneHourLater, timeOneDayLater, primitive.NilObjectID)
+		// Add 2 new meeting preparation tasks, one of which should be returned before the other
+		_, err = createTestMeetingPreparationTask(taskCollection, userID, "Should come first", primitive.NewObjectID().Hex(), false, timeOneHourLater, timeOneDayLater, primitive.NilObjectID)
+		assert.NoError(t, err)
+		_, err = createTestMeetingPreparationTask(taskCollection, userID, "Should come second", primitive.NewObjectID().Hex(), false, timeTwoHoursLater, timeOneDayLater, primitive.NilObjectID)
 		assert.NoError(t, err)
 
 		//Check that only 100 tasks are returned
 		res, err := api.GetMeetingPreparationTasksResult(userID, 0)
 		assert.NoError(t, err)
 		assert.Len(t, res, 100)
-		// Check that the first task is the one we added
-		assert.Equal(t, "Should be first", res[0].Title)
+
+		assert.Equal(t, "Should come first", res[98].Title)
+		// Check that the second task is the one we added
+		assert.Equal(t, "Should come second", res[99].Title)
 	})
 
 }


### PR DESCRIPTION
Order the meeting prep tasks by datime_start, where 'oldests' tasks come first.

From local testing: 
<img width="449" alt="Screenshot 2023-03-03 at 1 08 29 PM" src="https://user-images.githubusercontent.com/9156543/222795642-19aec594-3e7c-4a37-ad34-9f1acb7568a3.png">
