### PR TITLE
Remove large border stroke

### DIFF
--- a/frontend/src/components/atoms/GTTextField/toolbar/styles.ts
+++ b/frontend/src/components/atoms/GTTextField/toolbar/styles.ts
@@ -18,7 +18,7 @@ export const MenuContainer = styled.div`
     overflow-x: auto;
 `
 export const Divider = styled.div`
-    border-left: ${Border.stroke.large} solid ${Colors.background.border};
+    border-left: ${Border.stroke.medium} solid ${Colors.background.border};
     height: ${Spacing._16};
 `
 export const MarginLeftGap = styled.div`

--- a/frontend/src/components/molecules/GTInputSelect.tsx
+++ b/frontend/src/components/molecules/GTInputSelect.tsx
@@ -10,7 +10,7 @@ const InputContainer = styled.div<{ valid: boolean }>`
     display: flex;
     align-items: center;
     justify-content: center;
-    border: ${Border.stroke.large} solid ${Colors.background.dark};
+    border: ${Border.stroke.medium} solid ${Colors.background.dark};
     border-radius: 8px;
     outline: ${(props) => (props.valid ? 'none' : `1px solid ${Colors.status.red.default}`)};
     margin-bottom: 4px;

--- a/frontend/src/styles/border.ts
+++ b/frontend/src/styles/border.ts
@@ -7,5 +7,4 @@ export const radius = {
 export const stroke = {
     small: '0.5px',
     medium: '1px',
-    large: '2px',
 }


### PR DESCRIPTION
@scottmai I believe the only code to use this was yours so I'd appreciate if you helped verify that nothing looks different (it really shouldn't, it's 2px -> 1px). I believe the two screenshots I've attached are the two places that use this border

![image](https://user-images.githubusercontent.com/31417618/222798058-665a4cf6-7dfb-4551-ad30-b011d77f80ee.png)
![image](https://user-images.githubusercontent.com/31417618/222798114-66424b41-7513-414c-8e4f-1f4f73e2a0d0.png)
