### PR TITLE
Correctly invalidate meeting prep query after getting new events

### DIFF
--- a/frontend/src/services/api/events.hooks.ts
+++ b/frontend/src/services/api/events.hooks.ts
@@ -87,8 +87,9 @@ const useGetEvents = (params: { startISO: string; endISO: string }, calendarType
         {
             ...getBackgroundQueryOptions(EVENTS_REFETCH_INTERVAL),
             onSettled: () => {
-                // because apparently we only refetch calendars when we refetch events
-                queryClient.invalidateQueries(['calendars', 'meeting_preparation_tasks'])
+                // because we only refetch calendars when we refetch events
+                queryClient.invalidateQueries(['calendars'])
+                queryClient.invalidateQueries(['meeting_preparation_tasks'])
             },
         }
     )


### PR DESCRIPTION
Demo showing expected invalidation behavior: 

https://user-images.githubusercontent.com/9156543/223201918-075348e4-caf7-4db3-9a11-99c8667b28a9.mov

