### PR TITLE
Fix sorting bug where empty values were sorted above non-empty ones

### DIFF
--- a/frontend/src/utils/sortAndFilter/sortAndFilterItems.ts
+++ b/frontend/src/utils/sortAndFilter/sortAndFilterItems.ts
@@ -24,7 +24,7 @@ const sortAndFilterItems = <T>({ items, sort, sortDirection, filter, tieBreakerF
                     }
                 }
             } else {
-                if (a[sort.field] != null && b[sort.field] != null) {
+                if (a[sort.field] && b[sort.field]) {
                     if (sort.customComparator) {
                         result = sort.customComparator(a, b)
                     } else {


### PR DESCRIPTION
This was introduced in the caching refactor - do you guys know why this line was changed?

<img width="487" alt="image" src="https://user-images.githubusercontent.com/42781446/223293857-c968f243-6042-408d-af2f-a5b074297d2b.png">
