### PR TITLE
Fix is-linked check on Jira page

### DIFF
--- a/frontend/src/utils/utils.ts
+++ b/frontend/src/utils/utils.ts
@@ -55,7 +55,7 @@ export const isSlackLinked = (linkedAccounts: TLinkedAccount[]) => {
     return linkedAccounts.some((account) => account.name === 'Slack')
 }
 export const isJiraLinked = (linkedAccounts: TLinkedAccount[]) => {
-    return linkedAccounts.some((account) => account.name === 'Atlassian')
+    return linkedAccounts.some((account) => account.name === 'Jira')
 }
 export const isLinearLinked = (linkedAccounts: TLinkedAccount[]) => {
     return linkedAccounts.some((account) => account.name === 'Linear')


### PR DESCRIPTION
Our check to see if jira was linked was broken because the name of the jira linked account changed from 'Atlassian' -> 'Jira'

<img width="536" alt="image" src="https://user-images.githubusercontent.com/42781446/223498384-68ba58aa-65c6-4be7-a526-a11f903f80c7.png">
