### PR TITLE
Smart meeting join :)

### DIFF
--- a/frontend/src/hooks/useEventBanners.tsx
+++ b/frontend/src/hooks/useEventBanners.tsx
@@ -93,11 +93,12 @@ export default function useEventBanners(date: DateTime) {
     useKeyboardShortcut(
         'joinCurrentMeeting',
         useCallback(() => {
-            for (const event of eventsWithinTenMinutes.current) {
-                if (isEventWithinTenMinutes(event) && event.conference_call.url) {
-                    window.open(event.conference_call.url, '_blank')
-                }
-            }
+            const currentMeetings = eventsWithinTenMinutes.current.filter(
+                (event) => isEventWithinTenMinutes(event) && event.conference_call?.url
+            )
+            if (currentMeetings.length === 0) return
+            currentMeetings.sort((a, b) => +DateTime.fromISO(b.datetime_start) - +DateTime.fromISO(a.datetime_start))
+            window.open(currentMeetings[0].conference_call.url, '_blank')
         }, [eventsWithinTenMinutes]),
         !eventsWithinTenMinutes.current.find((event) => isEventWithinTenMinutes(event))?.conference_call.url
     )


### PR DESCRIPTION
- get all meetings starting within 10 minutes and currently happening.
- If there's just one meeting in that list, join it
- Otherwise, sort them by start time and join the one with the LATEST start time (so the NEXT meeting)
- This will prevent opening a meeting that's just about to end when trying to join the next meeting while still allowing people to join an in-progress meeting if they don't have another starting soon