### PR TITLE
Refactor task details actions and remove delete button for jira tasks in task details

### DIFF
--- a/frontend/src/components/radix/TaskActionsDropdown.tsx
+++ b/frontend/src/components/radix/TaskActionsDropdown.tsx
@@ -10,6 +10,7 @@ import GTIconButton from '../atoms/buttons/GTIconButton'
 import { Mini } from '../atoms/typography/Typography'
 import GTDropdownMenu from './GTDropdownMenu'
 import { GTMenuItem } from './RadixUIConstants'
+import { getDeleteLabel } from './TaskContextMenuWrapper'
 
 interface TaskActionsDropdownProps {
     task: TTaskV4
@@ -57,7 +58,7 @@ const TaskActionsDropdown = ({ task }: TaskActionsDropdownProps) => {
     })
 
     const getDeleteTaskAction = (): GTMenuItem => ({
-        label: task.is_deleted ? 'Restore task' : 'Delete task',
+        label: getDeleteLabel(task),
         icon: icons.trash,
         iconColor: 'red',
         textColor: 'red',

--- a/frontend/src/components/radix/TaskContextMenuWrapper.tsx
+++ b/frontend/src/components/radix/TaskContextMenuWrapper.tsx
@@ -19,7 +19,7 @@ import RecurringTaskTemplateModal from '../molecules/recurring-tasks/RecurringTa
 import GTContextMenu from './GTContextMenu'
 import { GTMenuItem } from './RadixUIConstants'
 
-const getDeleteLabel = (task: TTaskV4) => {
+export const getDeleteLabel = (task: TTaskV4) => {
     if (task.is_deleted) {
         return 'Restore task'
     }


### PR DESCRIPTION
Jira details:
![image](https://user-images.githubusercontent.com/42781446/223588890-18c1ddb1-4b4f-4b6b-8bf9-03aea53cce23.png)

Normal task details:
![image](https://user-images.githubusercontent.com/42781446/223588936-cc730637-cd94-476d-8782-e01a90cb04d4.png)

Done task:
![image](https://user-images.githubusercontent.com/42781446/223589117-52b949c7-080f-4be0-8fe3-48ff395f559e.png)

Deleted task:
![image](https://user-images.githubusercontent.com/42781446/223589152-e4eba07f-2833-439f-9e2b-9e25ba0cb89e.png)

note: I removed the "Restore task" option for deleted tasks because there is a "Restore task" button right next to this dropdown