### PR TITLE
Fix bug where incorrect status was shown on done tasks

### DIFF
--- a/backend/api/task_modify.go
+++ b/backend/api/task_modify.go
@@ -197,6 +197,9 @@ func ValidateFields(c *gin.Context, updateFields *TaskItemChangeableFields, task
 			c.JSON(400, gin.H{"detail": "status value not in all status field for task"})
 			return false
 		}
+		if statusToUpdateTo.IsCompletedStatus {
+			updateFields.Task.CompletedStatus = statusToUpdateTo
+		}
 
 		if (task.IsCompleted != nil) && ((*task.IsCompleted && !statusToUpdateTo.IsCompletedStatus) || (task.IsCompleted != nil && !*task.IsCompleted && statusToUpdateTo.IsCompletedStatus)) {
 			updateFields.IsCompleted = &statusToUpdateTo.IsCompletedStatus


### PR DESCRIPTION
There was a bug where changing the status of a task to "done" would move it to the Done folder, but it would show the previous status. This fixes it:
 
https://user-images.githubusercontent.com/42781446/223708234-52beabf0-3b70-4723-ad0c-04e80161ee23.mov

