### PR TITLE
Fix task selection after completion

### DIFF
--- a/frontend/src/components/views/TaskSectionView.tsx
+++ b/frontend/src/components/views/TaskSectionView.tsx
@@ -201,9 +201,9 @@ const TaskSectionView = () => {
             if (folderIndex == null || taskIndex == null) return
 
             if (folders.length === 0 || sortedTasks.length === 0) return
-            const previousTask = sortedTasks[taskIndex === 0 ? taskIndex + 1 : taskIndex - 1]
-            if (!previousTask) return
-            navigateToTask({ taskId: previousTask.id })
+            const taskToSelect = sortedTasks[taskIndex === 0 ? taskIndex + 1 : taskIndex - 1]
+            if (!taskToSelect) return
+            navigateToTask({ taskId: taskToSelect.id })
         },
         [folders, params.task]
     )


### PR DESCRIPTION
If the task is the first in the list, select the next task instead of previous