### PR TITLE
Load empty reviews into pull request

### DIFF
--- a/backend/external/github_pr.go
+++ b/backend/external/github_pr.go
@@ -696,12 +696,20 @@ func getComments(context context.Context, githubClient *github.Client, repositor
 		})
 	}
 	for _, review := range reviews {
-		if review.GetBody() == "" {
-			continue
+		body := review.GetBody()
+		if body == "" {
+			state := review.GetState()
+			if state == StateApproved {
+				body = "(Approved changes)"
+			} else if state == StateChangesRequested {
+				body = "(Requested changes)"
+			} else {
+				body = "(Reviewed changes)"
+			}
 		}
 		result = append(result, database.PullRequestComment{
 			Type:      constants.COMMENT_TYPE_TOPLEVEL,
-			Body:      review.GetBody(),
+			Body:      body,
 			Author:    review.User.GetLogin(),
 			CreatedAt: primitive.NewDateTimeFromTime(review.GetSubmittedAt()),
 		})

--- a/backend/external/github_pr_test.go
+++ b/backend/external/github_pr_test.go
@@ -829,12 +829,12 @@ func TestGetComments(t *testing.T) {
 				SubmittedAt: &reviewTime,
 				User:        &github.User{Login: &author},
 			},
-			{SubmittedAt: &reviewTime}, // empty body comment should be skipped
+			{SubmittedAt: &reviewTime},
 		}
 		comments, err := getComments(context, githubClient, repository, pullRequest, reviews, commentsURL, issueCommentsURL)
 
 		assert.NoError(t, err)
-		assert.Equal(t, 1, len(comments))
+		assert.Equal(t, 2, len(comments))
 		expectedComment := database.PullRequestComment{
 			Type:      constants.COMMENT_TYPE_TOPLEVEL,
 			Body:      "This is a review comment",
@@ -842,6 +842,13 @@ func TestGetComments(t *testing.T) {
 			CreatedAt: primitive.NewDateTimeFromTime(reviewTime),
 		}
 		assert.Equal(t, expectedComment, comments[0])
+		expectedComment2 := database.PullRequestComment{
+			Type:      constants.COMMENT_TYPE_TOPLEVEL,
+			Body:      "(Reviewed changes)",
+			Author:    "",
+			CreatedAt: primitive.NewDateTimeFromTime(reviewTime),
+		}
+		assert.Equal(t, expectedComment2, comments[1])
 	})
 	t.Run("ComboComments", func(t *testing.T) {
 		githubCommentsServer := testutils.GetMockAPIServer(t, 200, testutils.PullRequestCommentsPayload)


### PR DESCRIPTION
Will be helpful to see these in the comments view but main motivation is to make the dashboard reports more accurate and include all reviews in the db record.