### PR TITLE
Fix tooltip bug

### DIFF
--- a/frontend/src/components/radix/Tip.tsx
+++ b/frontend/src/components/radix/Tip.tsx
@@ -51,7 +51,7 @@ const Tip = ({
     disabled,
     fitContent = false,
 }: TooltipProps) => {
-    if (disabled || !content) return <>{children}</>
+    if (disabled || (!content && !shortcutName)) return <>{children}</>
 
     const shortcutLabel = overrideShortcutLabel ?? (shortcutName ? KEYBOARD_SHORTCUTS[shortcutName].label : null)
     const shortcut = overrideShortcut ?? (shortcutName ? KEYBOARD_SHORTCUTS[shortcutName].keyLabel : null)


### PR DESCRIPTION
Tooltips based on a shortcut name weren't appearing
<img width="184" alt="image" src="https://user-images.githubusercontent.com/42781446/224596433-0304b636-c31b-4f77-8197-d08c8f7f85db.png">
