### PR TITLE
Fix weirdness around due date selector

### DIFF
--- a/frontend/src/components/molecules/GTDatePicker.tsx
+++ b/frontend/src/components/molecules/GTDatePicker.tsx
@@ -85,6 +85,7 @@ const GTDatePicker = ({ initialDate, setDate, showIcon = true, onlyCalendar = fa
                     if (date.toDateString() === new Date().toDateString()) {
                         return {
                             border: `${Border.stroke.medium} solid ${Colors.legacyColors.purple}`,
+                            color: Colors.text.black,
                             zIndex: 1,
                         }
                     }


### PR DESCRIPTION
The text color was showing up as red on the weekend when it was the weekend. This is because we didn't explicitly set the color to black in the case where that date is today. It's red by default