### PR TITLE
Create new useGetSharedTask hook

### DIFF
--- a/frontend/src/components/views/SharedTaskView.tsx
+++ b/frontend/src/components/views/SharedTaskView.tsx
@@ -1,13 +1,18 @@
-import { Navigate } from 'react-router-dom'
+import { Navigate, useParams } from 'react-router-dom'
 import { usePreviewMode } from '../../hooks'
+import { useGetSharedTask } from '../../services/api/tasks.hooks'
 import Spinner from '../atoms/Spinner'
 import { BackgroundContainer } from '../molecules/shared_item_page/BackgroundContainer'
+import SharedItemBody from '../molecules/shared_item_page/SharedItemBody'
 import SharedItemHeader from '../molecules/shared_item_page/SharedItemHeader'
 
 const SharedTask = () => {
-    const { isPreviewMode, isLoading } = usePreviewMode()
+    const { isPreviewMode, isLoading: isPreviewModeLoading } = usePreviewMode()
+    const { taskId } = useParams()
 
-    if (!isPreviewMode && !isLoading) {
+    const { data: task, isLoading } = useGetSharedTask({ id: taskId ?? '' })
+
+    if (!isPreviewMode && !isPreviewModeLoading) {
         return <Navigate to="/" replace />
     }
     if (isLoading) {
@@ -16,7 +21,7 @@ const SharedTask = () => {
     return (
         <BackgroundContainer>
             <SharedItemHeader sharedType="Tasks" />
-            oo wee
+            <SharedItemBody>{task?.title}</SharedItemBody>
         </BackgroundContainer>
     )
 }

--- a/frontend/src/services/api/tasks.hooks.ts
+++ b/frontend/src/services/api/tasks.hooks.ts
@@ -90,6 +90,25 @@ export interface TPostCommentData {
     optimisticId: string
 }
 
+interface TGetSharedTaskParams {
+    id: string
+}
+const getSharedTask = async ({ id }: TGetSharedTaskParams, { signal }: QueryFunctionContext) => {
+    try {
+        const res = await apiClient.get(`/shareable_tasks/detail/${id}/`, { signal })
+        return castImmutable(res.data)
+    } catch {
+        throw new Error('getSharedTask failed')
+    }
+}
+
+export const useGetSharedTask = (params: TGetSharedTaskParams) => {
+    return useQuery<TTaskV4, void>(
+        'sharedTask',
+        (context) => getSharedTask(params, context),
+        getBackgroundQueryOptions()
+    )
+}
 export const useGetTasksV4 = (isEnabled = true) => {
     return useQuery<TTaskV4[], void>('tasks_v4', getTasksV4, { enabled: isEnabled, refetchOnMount: false })
 }


### PR DESCRIPTION
This hook is used to get a shareable task, and display the title of the task.

Demo shared task:
![image](https://user-images.githubusercontent.com/9156543/225082579-8bcdc35e-242d-4227-a2b2-daeff1612f04.png)

Shared task page:
![image](https://user-images.githubusercontent.com/9156543/225082670-3689a9f2-0d95-403a-8305-4b8921da6fb4.png)
