### PR TITLE
Add footer field to shared item view container

### DIFF
--- a/frontend/src/components/molecules/shared_item_page/SharedItemBody.tsx
+++ b/frontend/src/components/molecules/shared_item_page/SharedItemBody.tsx
@@ -1,3 +1,4 @@
+import { Divider } from '@mantine/core'
 import styled from 'styled-components'
 import { Border, Colors, Shadows, Spacing } from '../../../styles'
 
@@ -6,11 +7,31 @@ const SharedItemBody = styled.div`
     background: ${Colors.background.white};
     border-radius: ${Border.radius.medium};
     box-shadow: ${Shadows.deprecated_medium};
-    display: flex;
-    flex-direction: column;
-    padding: ${Spacing._24};
     gap: ${Spacing._24};
     margin: ${Spacing._24};
 `
 
-export default SharedItemBody
+const PaddedContainer = styled.div`
+    padding: ${Spacing._24};
+`
+
+interface SharedItemBodyContainerProps {
+    content: React.ReactNode
+    footer?: React.ReactNode
+}
+
+const SharedItemBodyContainer = ({ content, footer }: SharedItemBodyContainerProps) => {
+    return (
+        <SharedItemBody>
+            <PaddedContainer>{content}</PaddedContainer>
+            {footer && (
+                <>
+                    <Divider />
+                    <PaddedContainer>{footer}</PaddedContainer>
+                </>
+            )}
+        </SharedItemBody>
+    )
+}
+
+export default SharedItemBodyContainer

--- a/frontend/src/components/notes/SharedNoteView.tsx
+++ b/frontend/src/components/notes/SharedNoteView.tsx
@@ -7,17 +7,16 @@ import styled from 'styled-components'
 import { AUTHORIZATION_COOKE, SHARED_ITEM_INDEFINITE_DATE } from '../../constants'
 import useAnalyticsEventTracker from '../../hooks/useAnalyticsEventTracker'
 import { useGetNote, useGetNotes } from '../../services/api/notes.hooks'
-import { Colors, Spacing } from '../../styles'
+import { Spacing } from '../../styles'
 import { emptyFunction, getFormattedDuration, getHumanTimeSinceDateTime } from '../../utils/utils'
 import Flex from '../atoms/Flex'
 import GTTextField from '../atoms/GTTextField'
-import { Divider } from '../atoms/SectionDivider'
 import Spinner from '../atoms/Spinner'
 import { DeprecatedLabel } from '../atoms/typography/Typography'
 import { BackgroundContainer } from '../molecules/shared_item_page/BackgroundContainer'
 import ContentContainer from '../molecules/shared_item_page/ContentContainer'
 import NotAvailableMessage from '../molecules/shared_item_page/NotAvailableMessage'
-import SharedItemBody from '../molecules/shared_item_page/SharedItemBody'
+import SharedItemBodyContainer from '../molecules/shared_item_page/SharedItemBody'
 import SharedItemHeader from '../molecules/shared_item_page/SharedItemHeader'
 import NoteActionsDropdown from './NoteActionsDropdown'
 
@@ -55,30 +54,38 @@ const SharedNoteView = () => {
             <BackgroundContainer>
                 <ContentContainer>
                     <SharedItemHeader sharedType="Notes" />
-                    <SharedItemBody>
-                        {note && note.shared_until ? (
-                            <>
-                                <Flex alignItems="flex-start">
+                    <SharedItemBodyContainer
+                        content={
+                            note && note.shared_until ? (
+                                <>
+                                    <Flex alignItems="flex-start">
+                                        <GTTextField
+                                            type="plaintext"
+                                            value={note.title}
+                                            onChange={emptyFunction}
+                                            fontSize="large"
+                                            disabled
+                                            readOnly
+                                        />
+                                        <NoteActionsDropdown note={note} isOwner={isUserNoteOwner} />
+                                    </Flex>
                                     <GTTextField
-                                        type="plaintext"
-                                        value={note.title}
+                                        key={note.id}
+                                        type="markdown"
+                                        value={note.body}
                                         onChange={emptyFunction}
-                                        fontSize="large"
+                                        fontSize="small"
                                         disabled
                                         readOnly
                                     />
-                                    <NoteActionsDropdown note={note} isOwner={isUserNoteOwner} />
-                                </Flex>
-                                <GTTextField
-                                    key={note.id}
-                                    type="markdown"
-                                    value={note.body}
-                                    onChange={emptyFunction}
-                                    fontSize="small"
-                                    disabled
-                                    readOnly
-                                />
-                                <Divider color={Colors.background.border} />
+                                </>
+                            ) : (
+                                <NotAvailableMessage sharedType="Notes" />
+                            )
+                        }
+                        footer={
+                            note &&
+                            note.shared_until && (
                                 <FlexPadding8Horizontal justifyContent="space-between" alignItems="center">
                                     <Flex gap={Spacing._4}>
                                         {isLoggedIn && isUserNoteOwner ? (
@@ -111,11 +118,9 @@ const SharedNoteView = () => {
                                               )}`}
                                     </DeprecatedLabel>
                                 </FlexPadding8Horizontal>
-                            </>
-                        ) : (
-                            <NotAvailableMessage sharedType="Notes" />
-                        )}
-                    </SharedItemBody>
+                            )
+                        }
+                    />
                 </ContentContainer>
             </BackgroundContainer>
         </>

--- a/frontend/src/components/views/SharedTaskView.tsx
+++ b/frontend/src/components/views/SharedTaskView.tsx
@@ -8,7 +8,7 @@ import Spinner from '../atoms/Spinner'
 import GTDatePickerButton from '../molecules/GTDatePickerButton'
 import { BackgroundContainer } from '../molecules/shared_item_page/BackgroundContainer'
 import ContentContainer from '../molecules/shared_item_page/ContentContainer'
-import SharedItemBody from '../molecules/shared_item_page/SharedItemBody'
+import SharedItemBodyContainer from '../molecules/shared_item_page/SharedItemBody'
 import SharedItemHeader from '../molecules/shared_item_page/SharedItemHeader'
 
 const SharedTask = () => {
@@ -30,32 +30,37 @@ const SharedTask = () => {
         <BackgroundContainer>
             <ContentContainer>
                 <SharedItemHeader sharedType="Tasks" />
-                <SharedItemBody>
-                    <GTTextField
-                        type="plaintext"
-                        value={task?.title ?? ''}
-                        onChange={emptyFunction}
-                        fontSize="large"
-                        disabled
-                        readOnly
-                    />
-                    <GTDatePickerButton
-                        currentDate={DateTime.fromISO(task?.due_date ?? '')}
-                        showIcon
-                        onClick={emptyFunction}
-                        isOpen={false}
-                        disabled
-                        overrideDisabledStyle
-                    />
-                    <GTTextField
-                        type="markdown"
-                        value={task?.body ?? ''}
-                        onChange={emptyFunction}
-                        fontSize="small"
-                        disabled
-                        readOnly
-                    />
-                </SharedItemBody>
+                <SharedItemBodyContainer
+                    content={
+                        <>
+                            <GTTextField
+                                type="plaintext"
+                                value={task?.title ?? ''}
+                                onChange={emptyFunction}
+                                fontSize="large"
+                                disabled
+                                readOnly
+                            />
+                            <GTDatePickerButton
+                                currentDate={DateTime.fromISO(task?.due_date ?? '')}
+                                showIcon
+                                onClick={emptyFunction}
+                                isOpen={false}
+                                disabled
+                                overrideDisabledStyle
+                            />
+                            <GTTextField
+                                type="markdown"
+                                value={task?.body ?? ''}
+                                onChange={emptyFunction}
+                                fontSize="small"
+                                disabled
+                                readOnly
+                            />
+                        </>
+                    }
+                    footer={<div>this is a foooooter</div>}
+                />
             </ContentContainer>
         </BackgroundContainer>
     )


### PR DESCRIPTION
Demo of updated shared notes page with new footer:

<img width="1840" alt="Screenshot 2023-03-14 at 5 42 45 PM" src="https://user-images.githubusercontent.com/9156543/225147398-83d77345-564c-446a-8bc0-fc46e11a020c.png">
