### PR TITLE
Update shared task preview tests

### DIFF
--- a/backend/api/shareable_task_preview.go
+++ b/backend/api/shareable_task_preview.go
@@ -41,24 +41,24 @@ func (api *API) ShareableTaskPreview(c *gin.Context) {
 		previewTitle = html.EscapeString(*task.Title)
 	}
 	body := []byte(`
-	<!DOCTYPE html>
-	<html>
-	<head>
-		<title>` + previewTitle + `</title>
-		<meta http-equiv="Refresh" content="0; url='` + taskURL + `'" />
-	
-		<meta property="og:title" content="` + previewTitle + `" />
-		<meta name="twitter:title" content="` + previewTitle + `">
-	
-		<meta content="Task shared by ` + taskOwner.Name + ` via General Task." property="og:description">
-		<meta content="Task shared by ` + taskOwner.Name + ` via General Task." property="twitter:description">
-	
-		<meta property="og:type" content="website" />
-		<meta property="og:url" content="` + config.GetConfigValue("SERVER_URL") + "task/" + task.ID.Hex() + `/" />
-	</head>
-	<body>
-	</body>
-	</html>`)
+<!DOCTYPE html>
+<html>
+<head>
+	<title>` + previewTitle + `</title>
+	<meta http-equiv="Refresh" content="0; url='` + taskURL + `'" />
+
+	<meta property="og:title" content="` + previewTitle + `" />
+	<meta name="twitter:title" content="` + previewTitle + `">
+
+	<meta content="Task shared by ` + taskOwner.Name + ` via General Task." property="og:description">
+	<meta content="Task shared by ` + taskOwner.Name + ` via General Task." property="twitter:description">
+
+	<meta property="og:type" content="website" />
+	<meta property="og:url" content="` + config.GetConfigValue("SERVER_URL") + "task/" + task.ID.Hex() + `/" />
+</head>
+<body>
+</body>
+</html>`)
 	c.Data(200, "text/html; charset=utf-8", body)
 }
 


### PR DESCRIPTION
Test domain and public shared status separately. We were missing the public shared status test before