### PR TITLE
Sort dashboard data points by time

### DIFF
--- a/backend/api/dashboard_data.go
+++ b/backend/api/dashboard_data.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"sort"
 	"strconv"
 	"time"
 
@@ -193,6 +194,9 @@ func (api *API) DashboardData(c *gin.Context) {
 		dashboardData.Points = append(dashboardData.Points, DashboardPoint{
 			X: int(dataPoint.Date.Time().Unix()),
 			Y: dataPoint.Value,
+		})
+		sort.Slice(dashboardData.Points, func(i, j int) bool {
+			return dashboardData.Points[i].X < dashboardData.Points[j].X
 		})
 		data[subjectID][intervalID][dataID] = dashboardData
 	}

--- a/backend/api/dashboard_data_test.go
+++ b/backend/api/dashboard_data_test.go
@@ -306,12 +306,12 @@ func TestDashboardData(t *testing.T) {
 					"aggregated_value": 24,
 					"points": [
 						{
-							"x": 1672185600,
-							"y": 16
-						},
-						{
 							"x": 1672099200,
 							"y": 32
+						},
+						{
+							"x": 1672185600,
+							"y": 16
 						}
 					]
 				}
@@ -338,12 +338,12 @@ func TestDashboardData(t *testing.T) {
 					"aggregated_value": 102,
 					"points": [
 						{
-							"x": 1672185600,
-							"y": 100
-						},
-						{
 							"x": 1672099200,
 							"y": 105
+						},
+						{
+							"x": 1672185600,
+							"y": 100
 						}
 					]
 				}


### PR DESCRIPTION
Sorts line points because our charting library draws points in the order they are passed

before & after: 
<img width="442" alt="Screen Shot 2023-03-17 at 3 58 45 PM" src="https://user-images.githubusercontent.com/42781446/226020374-d76059fb-afd1-4faf-85f9-5c0db078a531.png">
<img width="443" alt="Screen Shot 2023-03-17 at 3 59 26 PM" src="https://user-images.githubusercontent.com/42781446/226020377-205cb50a-3bd4-4d40-892a-e376bf27b79e.png">
