### PR TITLE
Change "grey" to "gray" in dashboard endpoint

### DIFF
--- a/backend/api/dashboard_data.go
+++ b/backend/api/dashboard_data.go
@@ -74,7 +74,7 @@ const ICON_GCAL = "gcal"
 
 const COLOR_PINK = "pink"
 const COLOR_BLUE = "blue"
-const COLOR_GREY = "grey"
+const COLOR_GRAY = "gray"
 
 const TEAM_DAILY_AVERAGE = "Daily average (Your team)"
 const TEAM_WEEKLY_AVERAGE = "Weekly average (Your team)"
@@ -267,7 +267,7 @@ func getGraphs() map[primitive.ObjectID]DashboardGraph {
 			},
 			{
 				Name:           INDUSTRY_DAILY_AVERAGE,
-				Color:          COLOR_GREY,
+				Color:          COLOR_GRAY,
 				AggregatedName: INDUSTRY_WEEKLY_AVERAGE,
 				DataID:         DataIDPRChartIndustryAverage,
 			},
@@ -285,7 +285,7 @@ func getGraphs() map[primitive.ObjectID]DashboardGraph {
 			},
 			{
 				Name:           INDUSTRY_DAILY_AVERAGE,
-				Color:          COLOR_GREY,
+				Color:          COLOR_GRAY,
 				AggregatedName: INDUSTRY_WEEKLY_AVERAGE,
 				DataID:         DataIDFocusTimeIndustryAverage,
 			},
@@ -303,7 +303,7 @@ func getGraphs() map[primitive.ObjectID]DashboardGraph {
 			},
 			{
 				Name:           TEAM_DAILY_AVERAGE,
-				Color:          COLOR_GREY,
+				Color:          COLOR_GRAY,
 				AggregatedName: TEAM_WEEKLY_AVERAGE,
 				DataID:         DataIDPRChartTeamAverage,
 				SubjectID:      &SubjectIDTeam,
@@ -322,7 +322,7 @@ func getGraphs() map[primitive.ObjectID]DashboardGraph {
 			},
 			{
 				Name:           TEAM_DAILY_AVERAGE,
-				Color:          COLOR_GREY,
+				Color:          COLOR_GRAY,
 				AggregatedName: TEAM_WEEKLY_AVERAGE,
 				DataID:         DataIDFocusTimeTeamAverage,
 				SubjectID:      &SubjectIDTeam,

--- a/backend/api/dashboard_data_test.go
+++ b/backend/api/dashboard_data_test.go
@@ -222,7 +222,7 @@ func TestDashboardData(t *testing.T) {
 				},
 				{
 					"name": "Daily average (Industry)",
-					"color": "grey",
+					"color": "gray",
 					"aggregated_name": "Weekly average (Industry)",
 					"data_id": "000000000000000000000005",
 					"subject_id_override": null
@@ -242,7 +242,7 @@ func TestDashboardData(t *testing.T) {
 				},
 				{
 					"name": "Daily average (Your team)",
-					"color": "grey",
+					"color": "gray",
 					"aggregated_name": "Weekly average (Your team)",
 					"data_id": "000000000000000000000006",
 					"subject_id_override": "000000000000000000000101"
@@ -262,7 +262,7 @@ func TestDashboardData(t *testing.T) {
 				},
 				{
 					"name": "Daily average (Industry)",
-					"color": "grey",
+					"color": "gray",
 					"aggregated_name": "Weekly average (Industry)",
 					"data_id": "000000000000000000000008",
 					"subject_id_override": null
@@ -282,7 +282,7 @@ func TestDashboardData(t *testing.T) {
 				},
 				{
 					"name": "Daily average (Your team)",
-					"color": "grey",
+					"color": "gray",
 					"aggregated_name": "Weekly average (Your team)",
 					"data_id": "000000000000000000000009",
 					"subject_id_override": "000000000000000000000101"


### PR DESCRIPTION
The frontend was expecting "gray" as a color key, so some graphs weren't displaying correctly

![image](https://user-images.githubusercontent.com/42781446/226200604-19c92bde-7918-4637-a8c1-55d028fc64fe.png)

<img src="https://media0.giphy.com/media/wfrBXMdq2VJ84/giphy.gif"/>