### PR TITLE
Document edge case that occurs when starting backend locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,12 @@ go run .
 curl localhost:8080/ping
 ```
 
+If you encounter a failure with your go run, ensure you do not have an existing local Mongo instance running on your machine and listening on the same port:
+
+```
+netstat -na |grep '27017.*LISTEN'
+```
+
 ### Live-reloading / auto-recompile [highly recommended for devx]
 
 We can setup the server to rebuild/rerun upon local file changes using [air](https://github.com/cosmtrek/air) so you don't have to constantly kill the server and rerun it yourself.


### PR DESCRIPTION
There's a misleading error when starting up the backend if a local Mongo instance is running already. This adds some documentation to the README.