### PR TITLE
Don't show share w/ domain button if user does not have company email

### DIFF
--- a/frontend/src/components/molecules/TaskSharingDropdown.tsx
+++ b/frontend/src/components/molecules/TaskSharingDropdown.tsx
@@ -2,6 +2,7 @@ import { DateTime } from 'luxon'
 import { REACT_APP_TASK_BASE_URL, SHARED_ITEM_INDEFINITE_DATE } from '../../constants'
 import { useToast } from '../../hooks'
 import { useModifyTask } from '../../services/api/tasks.hooks'
+import { useGetUserInfo } from '../../services/api/user-info.hooks'
 import { icons } from '../../styles/images'
 import { TTaskSharedAccess, TTaskV4 } from '../../utils/types'
 import GTButton from '../atoms/buttons/GTButton'
@@ -14,6 +15,7 @@ interface TaskharingDropdownProps {
 
 const TaskSharingDropdown = ({ task }: TaskharingDropdownProps) => {
     const { mutate: modifyTask } = useModifyTask()
+    const { data: userInfo } = useGetUserInfo()
     const toast = useToast()
 
     const copyTaskLink = () => {
@@ -59,12 +61,16 @@ const TaskSharingDropdown = ({ task }: TaskharingDropdownProps) => {
             label: 'Share task with',
             hideCheckmark: true,
             subItems: [
-                {
-                    icon: icons.users,
-                    label: 'Share with company',
-                    hideCheckmark: true,
-                    onClick: () => shareAndCopy('domain'),
-                },
+                ...(userInfo?.is_company_email
+                    ? [
+                          {
+                              icon: icons.users,
+                              label: 'Share with company',
+                              hideCheckmark: true,
+                              onClick: () => shareAndCopy('domain'),
+                          },
+                      ]
+                    : []),
                 {
                     icon: icons.globe,
                     label: 'Share with everyone',
@@ -83,12 +89,16 @@ const TaskSharingDropdown = ({ task }: TaskharingDropdownProps) => {
         },
     ]
     const notSharedDropdownItems: GTMenuItem[] = [
-        {
-            icon: icons.users,
-            label: 'Share with company',
-            hideCheckmark: true,
-            onClick: () => shareAndCopy('domain'),
-        },
+        ...(userInfo?.is_company_email
+            ? [
+                  {
+                      icon: icons.users,
+                      label: 'Share with company',
+                      hideCheckmark: true,
+                      onClick: () => shareAndCopy('domain'),
+                  },
+              ]
+            : []),
         {
             icon: icons.globe,
             label: 'Share with everyone',


### PR DESCRIPTION
Behavior when using my personal gmail account with `@gmail` domain
<img width="192" alt="Screenshot 2023-03-20 at 1 21 01 PM" src="https://user-images.githubusercontent.com/9156543/226418641-d7eb0623-0d9c-4715-a412-27b24f9dc790.png">
<img width="413" alt="Screenshot 2023-03-20 at 1 21 06 PM" src="https://user-images.githubusercontent.com/9156543/226418682-a507cc27-cf75-4f83-94f2-8e276b0cf44c.png">
