### PR TITLE
Use markdown renderer to make body non-editable

### DIFF
--- a/frontend/src/components/views/SharedTaskView.tsx
+++ b/frontend/src/components/views/SharedTaskView.tsx
@@ -58,6 +58,9 @@ const TaskFieldContainer = styled.div`
     display: flex;
     margin-bottom: ${Spacing._12};
 `
+const MarkdownContainer = styled.div`
+    padding: 0 ${Spacing._8};
+`
 const SubtaskContainer = styled.div`
     margin-top: ${Spacing._24};
     display: flex;
@@ -125,7 +128,9 @@ const SharedTask = () => {
                                     <GTDatePickerButton currentDate={DateTime.fromISO(displayedTask?.due_date ?? '')} />
                                 </TaskFieldContainer>
                                 {displayedTask?.body.trim() ? (
-                                    <MarkdownRenderer>{displayedTask?.body}</MarkdownRenderer>
+                                    <MarkdownContainer>
+                                        <MarkdownRenderer>{displayedTask?.body}</MarkdownRenderer>
+                                    </MarkdownContainer>
                                 ) : (
                                     <EmptyBody />
                                 )}


### PR DESCRIPTION
Make sure that editor isn't actually editable. To do this, I switched to using `MarkdownRenderer`.

<img width="696" alt="Screenshot 2023-03-21 at 9 30 09 PM" src="https://user-images.githubusercontent.com/9156543/226778648-06e41413-771c-42bd-b754-de8161cb44b2.png">
