### PR TITLE
Fix global style bug

### DIFF
--- a/frontend/src/styles/GlobalStyle.tsx
+++ b/frontend/src/styles/GlobalStyle.tsx
@@ -1,8 +1,7 @@
 import { createGlobalStyle } from 'styled-components'
 import { Colors } from '.'
 
-const GlobalStyle = () => {
-    const Styles = createGlobalStyle`
+const GlobalStyle = createGlobalStyle`
     :root {
        --animate-duration: 250ms !important;
        --animate-border-easing: 150ms ease-out !important;
@@ -35,7 +34,5 @@ const GlobalStyle = () => {
     }
 
 `
-    return <Styles />
-}
 
 export default GlobalStyle


### PR DESCRIPTION
Resloves this warning 
<img width="456" alt="image" src="https://user-images.githubusercontent.com/42781446/227805133-02ac6068-5597-4312-8950-59bfb34b7379.png">


It also seemed to be causing the super dashboard chunk to break 🤷 