### PR TITLE
Aggregate based off task source

### DIFF
--- a/backend/api/daily_task_completion.go
+++ b/backend/api/daily_task_completion.go
@@ -63,6 +63,12 @@ func (api *API) GetDailyTaskCompletionList(userID primitive.ObjectID, datetimeSt
 			{Key: "count", Value: bson.D{{Key: "$sum", Value: 1}}}},
 		},
 	}
+	// Sort by source_id so that the sources are in alphabetical order
+	sortSourceStage := bson.D{
+		{Key: "$sort", Value: bson.D{
+			{Key: "_id.source_id", Value: 1},
+		}},
+	}
 	// Group by date string and push all sources with counts
 	groupStage2 := bson.D{
 		{Key: "$group", Value: bson.D{
@@ -91,7 +97,7 @@ func (api *API) GetDailyTaskCompletionList(userID primitive.ObjectID, datetimeSt
 		}},
 	}
 
-	pipeline := mongo.Pipeline{matchStage, projectStage, groupStage, groupStage2, sortStage, renameFieldsStage2}
+	pipeline := mongo.Pipeline{matchStage, projectStage, groupStage, sortSourceStage, groupStage2, sortStage, renameFieldsStage2}
 	cursor, err := taskCollection.Aggregate(context.Background(), pipeline)
 	if err != nil {
 		return nil, err

--- a/backend/api/daily_task_completion_test.go
+++ b/backend/api/daily_task_completion_test.go
@@ -90,11 +90,11 @@ func TestGetDailyTaskCompletionList(t *testing.T) {
 				Date: "2023-01-04",
 				Sources: []TaskCompletionSource{
 					{
-						SourceID: external.TASK_SOURCE_ID_LINEAR,
+						SourceID: external.TASK_SOURCE_ID_GT_TASK,
 						Count:    1,
 					},
 					{
-						SourceID: external.TASK_SOURCE_ID_GT_TASK,
+						SourceID: external.TASK_SOURCE_ID_LINEAR,
 						Count:    1,
 					},
 				},


### PR DESCRIPTION
Since the designs for streaks take into account the type of task that was completed, we needed to separate the counts by source_id. Here's an example response:

```
[
   {
        "date": "2023-03-01",
        "sources": [
            {
                "count": 5,
                "source_id": "gcal"
            },
            {
                "count": 32,
                "source_id": "gt_task"
            }
        ]
    },
    {
        "date": "2023-03-02",
        "sources": [
            {
                "count": 1,
                "source_id": "gcal"
            },
            {
                "count": 10,
                "source_id": "gt_task"
            },
            {
                "count": 1,
                "source_id": "linear_task"
            }
        ]
    },
]
```