### PR TITLE
Add onboarding page for b2b leaderboard

### DIFF
--- a/frontend/src/components/b2b/leaderboard/OnboardingSplash.tsx
+++ b/frontend/src/components/b2b/leaderboard/OnboardingSplash.tsx
@@ -83,8 +83,8 @@ const OnboardingSplash = () => {
                 <LinkedGithubAccounts>
                     <LabelSmall>GitHub account</LabelSmall>
                     {linkedGithubAccounts.map((account) => (
-                        <Flex key={account.id} justifyContent="space-between">
-                            <Flex gap={Spacing._8}>
+                        <Flex key={account.id} justifyContent="space-between" alignItems="center">
+                            <Flex gap={Spacing._8} alignItems="center">
                                 <Icon icon={icons.github} />
                                 <BodyMedium>{account.display_id}</BodyMedium>
                             </Flex>


### PR DESCRIPTION
Allows user to link, view, and unlink their github account
has a placeholder image on the right since we'll reuse the actual leaderboard components once that is built

![image](https://user-images.githubusercontent.com/42781446/228027653-97a0641d-cefb-4afa-a1eb-7bdfe8b69a83.png)
![image](https://user-images.githubusercontent.com/42781446/228027661-518f50bb-2f99-420b-a9a7-7275a85b8ee1.png)
