### PR TITLE
Add has_been_invited_to_leaderboard flag to dashboard team members response

### DIFF
--- a/backend/api/dashboard_team_members.go
+++ b/backend/api/dashboard_team_members.go
@@ -14,10 +14,11 @@ type DashboardTeamMemberCreateParams struct {
 	GithubID string `json:"github_id"`
 }
 type DashboardTeamMemberResult struct {
-	ID       string `json:"id,omitempty"`
-	Name     string `json:"name,omitempty"`
-	Email    string `json:"email,omitempty"`
-	GithubID string `json:"github_id,omitempty"`
+	ID                          string `json:"id,omitempty"`
+	Name                        string `json:"name,omitempty"`
+	Email                       string `json:"email,omitempty"`
+	GithubID                    string `json:"github_id,omitempty"`
+	HasBeenInvitedToLeaderboard bool   `json:"has_been_invited_to_leaderboard,omitempty"`
 }
 
 func (api *API) DashboardTeamMemberCreate(c *gin.Context) {
@@ -105,10 +106,11 @@ func (api *API) DashboardTeamMembersList(c *gin.Context) {
 	var teamMemberResults []DashboardTeamMemberResult
 	for _, dashboardTeamMember := range *dashboardTeamMembers {
 		teamMemberResults = append(teamMemberResults, DashboardTeamMemberResult{
-			ID:       dashboardTeamMember.ID.Hex(),
-			Name:     dashboardTeamMember.Name,
-			Email:    dashboardTeamMember.Email,
-			GithubID: dashboardTeamMember.GithubID,
+			ID:                          dashboardTeamMember.ID.Hex(),
+			Name:                        dashboardTeamMember.Name,
+			Email:                       dashboardTeamMember.Email,
+			GithubID:                    dashboardTeamMember.GithubID,
+			HasBeenInvitedToLeaderboard: dashboardTeamMember.HasBeenInvitedToLeaderboard,
 		})
 	}
 	c.JSON(200, teamMemberResults)

--- a/backend/api/dashboard_team_members_test.go
+++ b/backend/api/dashboard_team_members_test.go
@@ -180,10 +180,11 @@ func TestDashboardTeamMemberList(t *testing.T) {
 		assert.NoError(t, err)
 
 		teamMember1 := database.DashboardTeamMember{
-			TeamID:   dashboardTeam.ID,
-			Name:     "scott",
-			Email:    "scott@gt.com",
-			GithubID: "scottmai",
+			TeamID:                      dashboardTeam.ID,
+			Name:                        "scott",
+			Email:                       "scott@gt.com",
+			GithubID:                    "scottmai",
+			HasBeenInvitedToLeaderboard: true,
 		}
 		teamMember2 := database.DashboardTeamMember{
 			TeamID: dashboardTeam.ID,
@@ -219,10 +220,11 @@ func TestDashboardTeamMemberList(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, 4, len(result))
 		assertDashboardTeamMemberResultsAreEqual(t, DashboardTeamMemberResult{
-			ID:       insertResult.InsertedIDs[0].(primitive.ObjectID).Hex(),
-			Name:     "scott",
-			Email:    "scott@gt.com",
-			GithubID: "scottmai",
+			ID:                          insertResult.InsertedIDs[0].(primitive.ObjectID).Hex(),
+			Name:                        "scott",
+			Email:                       "scott@gt.com",
+			GithubID:                    "scottmai",
+			HasBeenInvitedToLeaderboard: true,
 		}, result[0])
 		assertDashboardTeamMemberResultsAreEqual(t, DashboardTeamMemberResult{
 			ID:    insertResult.InsertedIDs[1].(primitive.ObjectID).Hex(),
@@ -254,4 +256,5 @@ func assertDashboardTeamMemberResultsAreEqual(t *testing.T, expected, actual Das
 	assert.Equal(t, expected.Name, actual.Name)
 	assert.Equal(t, expected.Email, actual.Email)
 	assert.Equal(t, expected.GithubID, actual.GithubID)
+	assert.Equal(t, expected.HasBeenInvitedToLeaderboard, actual.HasBeenInvitedToLeaderboard)
 }

--- a/backend/database/models.go
+++ b/backend/database/models.go
@@ -460,10 +460,11 @@ type DashboardTeam struct {
 }
 
 type DashboardTeamMember struct {
-	ID        primitive.ObjectID `bson:"_id,omitempty"`
-	TeamID    primitive.ObjectID `bson:"team_id,omitempty"`
-	Email     string             `bson:"email,omitempty"`
-	GithubID  string             `bson:"github_id,omitempty"`
-	Name      string             `bson:"name,omitempty"`
-	CreatedAt primitive.DateTime `bson:"created_at,omitempty"`
+	ID                          primitive.ObjectID `bson:"_id,omitempty"`
+	TeamID                      primitive.ObjectID `bson:"team_id,omitempty"`
+	Email                       string             `bson:"email,omitempty"`
+	GithubID                    string             `bson:"github_id,omitempty"`
+	Name                        string             `bson:"name,omitempty"`
+	CreatedAt                   primitive.DateTime `bson:"created_at,omitempty"`
+	HasBeenInvitedToLeaderboard bool               `bson:"has_been_invited_to_leaderboard,omitempty"`
 }


### PR DESCRIPTION
needed to show which team members have been invited to the leaderboard
![image](https://user-images.githubusercontent.com/42781446/228038028-9abf2fb4-2b45-4803-8dd1-6a4233f67070.png)
